### PR TITLE
feat: module= support on find_definition / find_references

### DIFF
--- a/internal/surgeon/app/queries/module_test.go
+++ b/internal/surgeon/app/queries/module_test.go
@@ -171,3 +171,76 @@ func TestGraph_WithModule_AbsoluteDir_ReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "relative",
 		"error should mention that --dir must be a relative path when --module is set")
 }
+
+// TestFindDefinition_WithModule_FindsCobraSymbol verifies that FindDefinition
+// scoped to a dependency resolves the symbol inside the module cache and
+// returns a path relative to the module root.
+func TestFindDefinition_WithModule_FindsCobraSymbol(t *testing.T) {
+	handler := realHandler(t)
+
+	result, err := handler.FindDefinition(context.Background(), domain.ReferencesQuery{
+		Symbol: domain.SymbolRef{Name: "Command"},
+		Module: "github.com/spf13/cobra",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Definition.File, "expected a definition site")
+
+	assert.False(t, filepath.IsAbs(result.Definition.File),
+		"definition path %q should be relative to module root", result.Definition.File)
+	assert.NotContains(t, result.Definition.File, "@",
+		"definition path %q should not contain a version marker", result.Definition.File)
+	assert.Equal(t, "Command", result.Symbol.Name)
+}
+
+// TestFindReferences_WithModule_ReturnsRelativePaths verifies that
+// FindReferences scoped to a module returns reference paths relative to
+// the module root, matching the convention used by FindSymbols.
+func TestFindReferences_WithModule_ReturnsRelativePaths(t *testing.T) {
+	handler := realHandler(t)
+
+	result, err := handler.FindReferences(context.Background(), domain.ReferencesQuery{
+		Symbol:            domain.SymbolRef{Name: "Command"},
+		Module:            "github.com/spf13/cobra",
+		IncludeDefinition: true,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.References, "expected at least one reference")
+
+	for _, ref := range result.References {
+		assert.False(t, filepath.IsAbs(ref.File),
+			"reference path %q should be relative to module root", ref.File)
+		assert.NotContains(t, ref.File, "@",
+			"reference path %q should not contain a version marker", ref.File)
+	}
+	assert.False(t, filepath.IsAbs(result.Definition.File),
+		"definition path %q should be relative to module root", result.Definition.File)
+}
+
+// TestFindDefinition_WithModule_InvalidModule_ReturnsError verifies that
+// scoping to a module not in go.mod produces a descriptive error.
+func TestFindDefinition_WithModule_InvalidModule_ReturnsError(t *testing.T) {
+	handler := realHandler(t)
+
+	_, err := handler.FindDefinition(context.Background(), domain.ReferencesQuery{
+		Symbol: domain.SymbolRef{Name: "Command"},
+		Module: "github.com/this/does/not/exist/in/gomod",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a dependency",
+		"error should mention that the module is not a dependency")
+}
+
+// TestFindDefinition_WithModule_AbsoluteDir_ReturnsError verifies that
+// passing an absolute --dir together with --module is rejected.
+func TestFindDefinition_WithModule_AbsoluteDir_ReturnsError(t *testing.T) {
+	handler := realHandler(t)
+
+	_, err := handler.FindDefinition(context.Background(), domain.ReferencesQuery{
+		Symbol: domain.SymbolRef{Name: "Command"},
+		Module: "github.com/spf13/cobra",
+		Dir:    "/tmp/absolute",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "relative",
+		"error should mention that --dir must be a relative path when --module is set")
+}

--- a/internal/surgeon/app/queries/references.go
+++ b/internal/surgeon/app/queries/references.go
@@ -21,11 +21,12 @@ import (
 // object resolves — we still load packages with NeedTypes because the
 // symbol might be a method whose receiver must be matched by type.
 func (h *SurgeonQueriesHandler) FindDefinition(ctx context.Context, query domain.ReferencesQuery) (domain.ReferencesResult, error) {
-	obj, pkg, loaded, err := h.resolveSymbol(ctx, query)
+	obj, pkg, loaded, moduleRoot, err := h.resolveSymbol(ctx, query)
 	if err != nil {
 		return domain.ReferencesResult{}, err
 	}
 	def := objectLocation(obj, loaded)
+	relativizeLocation(&def, moduleRoot)
 	return domain.ReferencesResult{
 		Symbol:     symbolRefFromObject(obj, pkg),
 		Kind:       classifyObject(obj),
@@ -39,7 +40,7 @@ func (h *SurgeonQueriesHandler) FindDefinition(ctx context.Context, query domain
 // The resulting slice includes no duplicates and is sorted by
 // file/line/column.
 func (h *SurgeonQueriesHandler) FindReferences(ctx context.Context, query domain.ReferencesQuery) (domain.ReferencesResult, error) {
-	obj, pkg, loaded, err := h.resolveSymbol(ctx, query)
+	obj, pkg, loaded, moduleRoot, err := h.resolveSymbol(ctx, query)
 	if err != nil {
 		return domain.ReferencesResult{}, err
 	}
@@ -47,6 +48,10 @@ func (h *SurgeonQueriesHandler) FindReferences(ctx context.Context, query domain
 	def := objectLocation(obj, loaded)
 	refs := collectReferences(obj, loaded)
 	sortLocations(refs)
+	relativizeLocation(&def, moduleRoot)
+	for i := range refs {
+		relativizeLocation(&refs[i], moduleRoot)
+	}
 
 	out := domain.ReferencesResult{
 		Symbol:     symbolRefFromObject(obj, pkg),
@@ -71,28 +76,43 @@ type loadedPackages struct {
 // their type information until it finds the declaration of the named
 // symbol. It is the workhorse that both FindDefinition, FindReferences,
 // and the rename command rely on.
-func (h *SurgeonQueriesHandler) resolveSymbol(ctx context.Context, query domain.ReferencesQuery) (types.Object, *packages.Package, *loadedPackages, error) {
+func (h *SurgeonQueriesHandler) resolveSymbol(ctx context.Context, query domain.ReferencesQuery) (types.Object, *packages.Package, *loadedPackages, string, error) {
 	if query.Symbol.Name == "" {
-		return nil, nil, nil, fmt.Errorf("symbol.name is required")
+		return nil, nil, nil, "", fmt.Errorf("symbol.name is required")
 	}
 
 	dir := query.Dir
-	if dir == "" {
+	var moduleRoot string
+	if query.Module != "" {
+		info, err := h.resolver.Resolve(ctx, query.Module)
+		if err != nil {
+			return nil, nil, nil, "", err
+		}
+		moduleRoot = info.Dir
+		switch {
+		case dir == "" || dir == ".":
+			dir = info.Dir
+		case filepath.IsAbs(dir):
+			return nil, nil, nil, "", fmt.Errorf("dir must be a relative path when module is set; got %q", dir)
+		default:
+			dir = filepath.Join(info.Dir, dir)
+		}
+	} else if dir == "" {
 		dir = "."
 	}
 	absDir, err := filepath.Abs(dir)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("resolve dir %q: %w", dir, err)
+		return nil, nil, nil, "", fmt.Errorf("resolve dir %q: %w", dir, err)
 	}
 
 	loadedPkgs, err := h.loader.Load(ctx, absDir, query.Tests)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, "", err
 	}
 	fset := loadedPkgs.Fset
 	pkgs := loadedPkgs.Pkgs
 	if len(pkgs) == 0 {
-		return nil, nil, nil, fmt.Errorf("no Go packages found under %q", absDir)
+		return nil, nil, nil, "", fmt.Errorf("no Go packages found under %q", absDir)
 	}
 
 	// Surface hard loader errors (missing deps, parse failures). A
@@ -103,7 +123,7 @@ func (h *SurgeonQueriesHandler) resolveSymbol(ctx context.Context, query domain.
 			// Only elevate errors from packages the user asked for.
 			// Transitive-dep errors are surfaced with a package prefix.
 			if e.Kind == packages.TypeError || e.Kind == packages.ParseError {
-				return nil, nil, nil, fmt.Errorf("%s: %s", p.PkgPath, e.Msg)
+				return nil, nil, nil, "", fmt.Errorf("%s: %s", p.PkgPath, e.Msg)
 			}
 		}
 	}
@@ -112,9 +132,9 @@ func (h *SurgeonQueriesHandler) resolveSymbol(ctx context.Context, query domain.
 
 	obj, pkg, err := findObject(loaded, query.Symbol)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, "", err
 	}
-	return obj, pkg, loaded, nil
+	return obj, pkg, loaded, moduleRoot, nil
 }
 
 // findObject walks the type-checked packages looking for the symbol's
@@ -450,4 +470,16 @@ func classifyObject(obj types.Object) string {
 		return "package"
 	}
 	return "symbol"
+}
+
+// relativizeLocation rewrites loc.File to a path relative to moduleRoot
+// when the location lives under that root. Used so module-scoped lookups
+// return paths consistent with FindSymbols (relative, no version marker).
+func relativizeLocation(loc *domain.Location, moduleRoot string) {
+	if moduleRoot == "" || loc == nil || loc.File == "" {
+		return
+	}
+	if rel, err := filepath.Rel(moduleRoot, loc.File); err == nil && !strings.HasPrefix(rel, "..") {
+		loc.File = rel
+	}
 }

--- a/internal/surgeon/domain/references.go
+++ b/internal/surgeon/domain/references.go
@@ -38,6 +38,10 @@ type ReferencesQuery struct {
 	IncludeDefinition bool
 	// Tests, when true, also loads _test.go files.
 	Tests bool
+	// Module, when set, scopes the lookup to that dependency's source
+	// instead of the current project. Dir is interpreted relative to the
+	// resolved module root when Module is set.
+	Module string
 }
 
 // Location is a file:line:column position inside a Go source file,

--- a/internal/surgeon/inbound/cli/commands/references.go
+++ b/internal/surgeon/inbound/cli/commands/references.go
@@ -14,7 +14,7 @@ import (
 // declaration — useful when grep gives too many matches or when the
 // caller wants a type-aware resolution.
 func NewFindDefinitionCommand(queries service.SurgeonQueries) *cobra.Command {
-	var receiver, pkg, file, dir string
+	var receiver, pkg, file, dir, module string
 	var line int
 	var tests bool
 
@@ -23,10 +23,12 @@ func NewFindDefinitionCommand(queries service.SurgeonQueries) *cobra.Command {
 		Short: "Locate the declaration of a Go symbol (type-aware)",
 		Long: `Resolves the symbol via go/packages and prints the file:line:column
 of its declaration. Pair NAME with --receiver / --package / --file / --line
-to disambiguate when the name is not unique.`,
+to disambiguate when the name is not unique. Use --module to look inside a
+dependency's source instead of the current project.`,
 		Example: `  go-surgeon find-definition BookRepository
   go-surgeon find-definition Handle --receiver BookHandler
-  go-surgeon find-definition Config --package internal/surgeon/domain`,
+  go-surgeon find-definition Config --package internal/surgeon/domain
+  go-surgeon find-definition Command --module github.com/spf13/cobra`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -38,8 +40,9 @@ to disambiguate when the name is not unique.`,
 					File:     file,
 					Line:     line,
 				},
-				Dir:   dir,
-				Tests: tests,
+				Dir:    dir,
+				Tests:  tests,
+				Module: module,
 			})
 			if err != nil {
 				return err
@@ -61,13 +64,14 @@ to disambiguate when the name is not unique.`,
 	cmd.Flags().IntVar(&line, "line", 0, "Declaration line (1-based); pair with --file")
 	cmd.Flags().StringVarP(&dir, "dir", "d", ".", "Directory to load packages from")
 	cmd.Flags().BoolVarP(&tests, "tests", "t", false, "Include _test.go files in the search")
+	cmd.Flags().StringVar(&module, "module", "", "Import path of a dependency to search in instead of the current project")
 	return cmd
 }
 
 // NewFindReferencesCommand wires the find-references CLI subcommand.
 // Prints each site the type-checker attributes to the resolved symbol.
 func NewFindReferencesCommand(queries service.SurgeonQueries) *cobra.Command {
-	var receiver, pkg, file, dir string
+	var receiver, pkg, file, dir, module string
 	var line int
 	var tests, includeDef bool
 
@@ -76,10 +80,12 @@ func NewFindReferencesCommand(queries service.SurgeonQueries) *cobra.Command {
 		Short: "Find every reference to a Go symbol across the module",
 		Long: `Loads the module via go/packages and prints file:line:column for every
 identifier that resolves to the named symbol. Use --include-definition to
-also print the declaration.`,
+also print the declaration. Use --module to look inside a dependency's
+source instead of the current project.`,
 		Example: `  go-surgeon find-references BookRepository
   go-surgeon find-references Handle --receiver BookHandler --include-definition
-  go-surgeon find-references helper --tests`,
+  go-surgeon find-references helper --tests
+  go-surgeon find-references Command --module github.com/spf13/cobra`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -94,6 +100,7 @@ also print the declaration.`,
 				Dir:               dir,
 				Tests:             tests,
 				IncludeDefinition: includeDef,
+				Module:            module,
 			})
 			if err != nil {
 				return err
@@ -120,6 +127,7 @@ also print the declaration.`,
 	cmd.Flags().StringVarP(&dir, "dir", "d", ".", "Directory to load packages from")
 	cmd.Flags().BoolVarP(&tests, "tests", "t", false, "Include _test.go files in the search")
 	cmd.Flags().BoolVar(&includeDef, "include-definition", false, "Also print the definition site")
+	cmd.Flags().StringVar(&module, "module", "", "Import path of a dependency to search in instead of the current project")
 	return cmd
 }
 

--- a/internal/surgeon/inbound/mcp/batch_query.go
+++ b/internal/surgeon/inbound/mcp/batch_query.go
@@ -218,6 +218,7 @@ func dispatchBatchFindReferences(ctx context.Context, queries service.SurgeonQue
 		Dir:               item.Dir,
 		Tests:             item.Tests,
 		IncludeDefinition: item.IncludeDefinition,
+		Module:            item.Module,
 	}
 	result, err := queries.FindReferences(ctx, q)
 	if err != nil {
@@ -239,8 +240,9 @@ func dispatchBatchFindDefinition(ctx context.Context, queries service.SurgeonQue
 			File:     item.File,
 			Line:     item.Line,
 		},
-		Dir:   item.Dir,
-		Tests: item.Tests,
+		Dir:    item.Dir,
+		Tests:  item.Tests,
+		Module: item.Module,
 	}
 	result, err := queries.FindDefinition(ctx, q)
 	if err != nil {

--- a/internal/surgeon/inbound/mcp/references_tools.go
+++ b/internal/surgeon/inbound/mcp/references_tools.go
@@ -22,6 +22,7 @@ type referencesInput struct {
 	Dir               string `json:"dir,omitempty" jsonschema:"directory to load packages from (defaults to '.')"`
 	Tests             bool   `json:"tests,omitempty" jsonschema:"include _test.go files when resolving and scanning for references"`
 	IncludeDefinition bool   `json:"include_definition,omitempty" jsonschema:"on find_references only: also return the definition site; defaults to false"`
+	Module            string `json:"module,omitempty" jsonschema:"import path of a dependency to search in instead of the current project, e.g. 'github.com/spf13/cobra'"`
 }
 
 // renameInput drives the rename_symbol MCP tool.
@@ -75,7 +76,7 @@ type renameOutput struct {
 func registerReferencesTools(s *mcp.Server, queries service.SurgeonQueries) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "find_definition",
-		Description: "Locate the declaration of a Go symbol (function, method, type, var, const, or struct field). Resolution is type-aware via go/packages — works across packages, including when the same name exists in multiple packages. Returns file:line:column of the defining identifier. Pair name with receiver/package/file+line when ambiguous.",
+		Description: "Locate the declaration of a Go symbol (function, method, type, var, const, or struct field). Resolution is type-aware via go/packages — works across packages, including when the same name exists in multiple packages. Returns file:line:column of the defining identifier. Pair name with receiver/package/file+line when ambiguous. Works on dependencies via module='github.com/org/repo' — paths are returned relative to the module root.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, in referencesInput) (*mcp.CallToolResult, any, error) {
 		if in.Name == "" {
 			return errorResult("find_definition: name is required"), nil, nil
@@ -88,8 +89,9 @@ func registerReferencesTools(s *mcp.Server, queries service.SurgeonQueries) {
 				File:     in.File,
 				Line:     in.Line,
 			},
-			Dir:   in.Dir,
-			Tests: in.Tests,
+			Dir:    in.Dir,
+			Tests:  in.Tests,
+			Module: in.Module,
 		}
 		result, err := queries.FindDefinition(ctx, q)
 		if err != nil {
@@ -104,7 +106,7 @@ func registerReferencesTools(s *mcp.Server, queries service.SurgeonQueries) {
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "find_references",
-		Description: "Find every reference to a Go symbol across the module, using go/packages type information. Returns file:line:column for each use, deduplicated and sorted. Set include_definition=true to also get the declaration site in one call. Use this before a rename to preview impact.",
+		Description: "Find every reference to a Go symbol across the module, using go/packages type information. Returns file:line:column for each use, deduplicated and sorted. Set include_definition=true to also get the declaration site in one call. Use this before a rename to preview impact. Works on dependencies via module='github.com/org/repo' — paths are returned relative to the module root.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, in referencesInput) (*mcp.CallToolResult, any, error) {
 		if in.Name == "" {
 			return errorResult("find_references: name is required"), nil, nil
@@ -120,6 +122,7 @@ func registerReferencesTools(s *mcp.Server, queries service.SurgeonQueries) {
 			Dir:               in.Dir,
 			Tests:             in.Tests,
 			IncludeDefinition: in.IncludeDefinition,
+			Module:            in.Module,
 		}
 		result, err := queries.FindReferences(ctx, q)
 		if err != nil {


### PR DESCRIPTION
Closes #1.

## Summary

- Adds `module=github.com/org/repo` to `find_definition` and `find_references` (MCP, CLI, batch_query) to scope lookups into a dependency.
- Returned paths are relative to the module root, with no version marker — same convention as `FindSymbols` and `Graph` already use.
- `dir` is interpreted relative to the module root when `module` is set; absolute `dir` is rejected.

## Implementation

- `domain.ReferencesQuery` gets a `Module` field.
- `SurgeonQueriesHandler.resolveSymbol` resolves the dependency via the existing `moduleResolver` and uses the module root as the loader directory. The function now also returns the `moduleRoot` so callers can relativize paths.
- A small `relativizeLocation` helper rewrites file paths in `Definition` and `References`.
- `find-definition` and `find-references` CLI commands gain a `--module` flag.
- `batch_query`'s find_* dispatchers propagate the existing shared `Module` field.

## Test plan

- [x] 4 new integration tests in `internal/surgeon/app/queries/module_test.go` covering the cobra dependency, error on invalid module, error on absolute `dir`.
- [x] Full suite: 589 passed, 0 failed.
- [x] golangci-lint: 0 issues.