### PR TITLE
ci: pin golangci-lint to latest released tag (closes #6)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,9 @@ jobs:
         run: go vet ./...
       - name: Install and run golangci-lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin
+          LATEST=$(curl -sSfL https://api.github.com/repos/golangci/golangci-lint/releases/latest | grep -o '"tag_name": *"[^"]*"' | head -1 | cut -d'"' -f4)
+          echo "Installing golangci-lint $LATEST"
+          curl -sSfL "https://raw.githubusercontent.com/golangci/golangci-lint/$LATEST/install.sh" | sh -s -- -b /usr/local/bin "$LATEST"
           golangci-lint run ./...
       - name: Run govulncheck
         run: |


### PR DESCRIPTION
Closes #6

## Summary
The lint job's installer was being pulled from `master` with no version pin. Upstream tag resolution started failing on 2026-04-25 (default version resolves to empty string), breaking CI.

This change resolves the latest released tag at workflow runtime via the GitHub API, then installs that exact version.

## Test plan
- [ ] CI lint job successfully installs golangci-lint and runs