### PR TITLE
feat(patch): suggest update as fallback for multi-line edits (closes #5)

### DIFF
--- a/internal/surgeon/inbound/mcp/describe_tool.go
+++ b/internal/surgeon/inbound/mcp/describe_tool.go
@@ -30,7 +30,9 @@ type toolEntry struct {
 	Summary  string // one-line "when to use"
 	Example  string // optional canonical example JSON arguments
 	Related  string // comma-separated names of related tools (optional)
-	Ops      map[string]toolOpEntry
+	// optional list of known limitations / edge cases with workarounds — surfaced under a 'limitations:' section in the per-tool detail view
+	Limitations []string
+	Ops         map[string]toolOpEntry
 }
 
 // toolCatalog is the machine-readable version of serverInstructions.
@@ -46,7 +48,11 @@ var toolCatalog = []toolEntry{
 	{Name: "rename_symbol", Category: "refs", Summary: "type-aware: rename a symbol and every reference; blocks export-status flips and in-scope collisions; preview=true for dry run", Example: `{"name": "OldName", "new_name": "NewName", "preview": true}`, Related: "find_references"},
 
 	// EDIT — narrowest first
-	{Name: "patch", Category: "edit", Summary: "edit Go source by target: function (body lines), struct (fields), interface (methods+mock), file (whole-file substitution), decl (const/var values). Set target= to select.", Example: `{"target": "function", "file": "foo.go", "identifier": "Foo", "patches": [{"op": "replace", "match": "x", "replace": "y"}]}`, Related: "update, patch_function_bulk, patch_struct_bulk", Ops: patchOps},
+	{Name: "patch", Category: "edit", Summary: "edit Go source by target: function (body lines), struct (fields), interface (methods+mock), file (whole-file substitution), decl (const/var values). Set target= to select.", Example: `{"target": "function", "file": "foo.go", "identifier": "Foo", "patches": [{"op": "replace", "match": "x", "replace": "y"}]}`, Related: "update, patch_function_bulk, patch_struct_bulk", Limitations: []string{
+		"multi-line replacement: op=replace can mis-splice multi-line replacements (issue #3) — workaround: use 'update object=func' (or update object=struct) with the full new declaration",
+		"replacement containing tabs/escapes: literal tab characters and escape sequences inside a multi-line replace value can confuse the splice — workaround: use 'update object=func' which takes raw Go source verbatim",
+		"large struct-literal field insertion: inserting many fields into a big struct literal via op=replace is fragile — workaround: use 'update object=func' to rewrite the whole declaration that contains the literal",
+	}, Ops: patchOps},
 	{Name: "patch.function", Category: "edit", Summary: "ops for target=function: replace, insert_before, insert_after, delete, wrap, set_signature", Ops: patchFunctionOps},
 	{Name: "patch.struct", Category: "edit", Summary: "ops for target=struct: add_field, remove_field, rename_field, retype_field, set_tag, set_doc", Ops: patchStructOps},
 	{Name: "patch.interface", Category: "edit", Summary: "ops for target=interface: add_method, remove_method, rename_method, retype_method, set_doc, embed, remove_embed", Ops: patchInterfaceOps},
@@ -307,6 +313,12 @@ func renderDescribeOne(name, format string) *mcp.CallToolResult {
 			if e.Related != "" {
 				fmt.Fprintf(&sb, "  see also: %s\n", e.Related)
 			}
+			if len(e.Limitations) > 0 {
+				sb.WriteString("  limitations:\n")
+				for _, lim := range e.Limitations {
+					fmt.Fprintf(&sb, "    - %s\n", lim)
+				}
+			}
 			return textResult(sb.String())
 		}
 	}
@@ -486,11 +498,12 @@ func canonicalOpOrder(ops map[string]toolOpEntry) []string {
 // shape exposed via StructuredContent.
 func toolEntryJSON(e toolEntry) toolEntryOut {
 	return toolEntryOut{
-		Name:     e.Name,
-		Category: e.Category,
-		Summary:  e.Summary,
-		Example:  e.Example,
-		Related:  e.Related,
+		Name:        e.Name,
+		Category:    e.Category,
+		Summary:     e.Summary,
+		Example:     e.Example,
+		Related:     e.Related,
+		Limitations: e.Limitations,
 	}
 }
 
@@ -512,11 +525,12 @@ func jsonResult(payload any) *mcp.CallToolResult {
 
 // toolEntryOut is the JSON projection of toolEntry (catalog row).
 type toolEntryOut struct {
-	Name     string `json:"name"`
-	Category string `json:"category"`
-	Summary  string `json:"summary"`
-	Example  string `json:"example,omitempty"`
-	Related  string `json:"related,omitempty"`
+	Name        string   `json:"name"`
+	Category    string   `json:"category"`
+	Summary     string   `json:"summary"`
+	Example     string   `json:"example,omitempty"`
+	Related     string   `json:"related,omitempty"`
+	Limitations []string `json:"limitations,omitempty"`
 }
 
 // describeToolOutput is the JSON shape for name=X (single tool).

--- a/internal/surgeon/inbound/mcp/helpers.go
+++ b/internal/surgeon/inbound/mcp/helpers.go
@@ -370,6 +370,7 @@ type patchFileOutput struct {
 	Diff         string   `json:"diff,omitempty"`
 	AddedImports []string `json:"added_imports,omitempty"`
 	Warnings     []string `json:"warnings,omitempty"`
+	Hint         string   `json:"hint,omitempty"`
 }
 
 // patchOutput is the structured result for patch_function, patch_struct and patch_interface.
@@ -382,6 +383,7 @@ type patchOutput struct {
 	MockUpdated  bool           `json:"mock_updated,omitempty"`
 	AddedImports []string       `json:"added_imports,omitempty"`
 	Warnings     []string       `json:"warnings,omitempty"`
+	Hint         string         `json:"hint,omitempty"`
 	AutoLifts    []autoLiftJSON `json:"auto_lifts,omitempty"`
 }
 

--- a/internal/surgeon/inbound/mcp/patch_hint_test.go
+++ b/internal/surgeon/inbound/mcp/patch_hint_test.go
@@ -1,0 +1,196 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// shortReplaceFn returns a fake patch_function/patch_decl handler whose
+// command-layer result reports success. The hint logic lives in the MCP
+// handler (it inspects the input ops, not the command result), so the
+// mocked applied count is enough.
+func newShortReplaceCommands() *mockCommands {
+	return &mockCommands{}
+}
+
+// TestPatch_Function_ReplaceShorter_AddsHint asserts that op=replace with
+// a replacement shorter than the match attaches the "try update object=func"
+// hint to both the text and StructuredContent of patch (target=function).
+func TestPatch_Function_ReplaceShorter_AddsHint(t *testing.T) {
+	cs := setupTest(t, newShortReplaceCommands(), &mockQueries{})
+
+	result := callTool(t, cs, "patch", map[string]any{
+		"target":     "function",
+		"file":       "foo.go",
+		"identifier": "Foo",
+		"patches": []map[string]any{
+			{"op": "replace", "match": "verylongmatchcontent", "replace": "x"},
+		},
+	})
+	require.False(t, result.IsError, resultText(t, result))
+
+	text := resultText(t, result)
+	assert.Contains(t, text, "HINT:")
+	assert.Contains(t, text, "update object=func")
+
+	require.NotNil(t, result.StructuredContent)
+	buf, err := json.Marshal(result.StructuredContent)
+	require.NoError(t, err)
+	var payload struct {
+		Hint string `json:"hint"`
+	}
+	require.NoError(t, json.Unmarshal(buf, &payload))
+	assert.Contains(t, payload.Hint, "update object=func")
+	assert.Contains(t, payload.Hint, "shorter than input")
+}
+
+// TestPatch_Function_ReplaceSameOrLonger_NoHint asserts that the hint is
+// NOT attached when the replacement is the same length or longer than the
+// match — the heuristic must not fire on healthy edits.
+func TestPatch_Function_ReplaceSameOrLonger_NoHint(t *testing.T) {
+	cs := setupTest(t, newShortReplaceCommands(), &mockQueries{})
+
+	result := callTool(t, cs, "patch", map[string]any{
+		"target":     "function",
+		"file":       "foo.go",
+		"identifier": "Foo",
+		"patches": []map[string]any{
+			{"op": "replace", "match": "abc", "replace": "abcdef"},
+		},
+	})
+	require.False(t, result.IsError, resultText(t, result))
+	assert.NotContains(t, resultText(t, result), "HINT:")
+
+	require.NotNil(t, result.StructuredContent)
+	buf, err := json.Marshal(result.StructuredContent)
+	require.NoError(t, err)
+	var payload struct {
+		Hint string `json:"hint"`
+	}
+	require.NoError(t, json.Unmarshal(buf, &payload))
+	assert.Empty(t, payload.Hint)
+}
+
+// TestPatch_Decl_ReplaceShorter_AddsHint mirrors the function-target test
+// for target=decl — patch_decl must surface the same hint when the splice
+// would shrink the decl value.
+func TestPatch_Decl_ReplaceShorter_AddsHint(t *testing.T) {
+	cs := setupTest(t, newShortReplaceCommands(), &mockQueries{})
+
+	result := callTool(t, cs, "patch", map[string]any{
+		"target":     "decl",
+		"file":       "foo.go",
+		"identifier": "banner",
+		"patches": []map[string]any{
+			{"op": "replace", "match": "longoriginalvalue", "replace": "tiny"},
+		},
+	})
+	require.False(t, result.IsError, resultText(t, result))
+	assert.Contains(t, resultText(t, result), "HINT:")
+	assert.Contains(t, resultText(t, result), "update object=func")
+}
+
+// TestPatch_File_ReplaceShorter_AddsHint covers target=file (whole-file
+// substitution). Same heuristic, same hint text.
+func TestPatch_File_ReplaceShorter_AddsHint(t *testing.T) {
+	cs := setupTest(t, newShortReplaceCommands(), &mockQueries{})
+
+	result := callTool(t, cs, "patch", map[string]any{
+		"target": "file",
+		"file":   "foo.go",
+		"patches": []map[string]any{
+			{"match": "longoldname", "replace": "x"},
+		},
+	})
+	require.False(t, result.IsError, resultText(t, result))
+	text := resultText(t, result)
+	assert.Contains(t, text, "HINT:")
+	assert.Contains(t, text, "update object=func")
+}
+
+// TestPatch_NonReplaceOp_NoHint asserts that ops other than replace
+// (e.g. insert_before) never trigger the hint, even if their fields look
+// shorter — the hint is gated on op="replace".
+func TestPatch_NonReplaceOp_NoHint(t *testing.T) {
+	cs := setupTest(t, newShortReplaceCommands(), &mockQueries{})
+
+	result := callTool(t, cs, "patch", map[string]any{
+		"target":     "function",
+		"file":       "foo.go",
+		"identifier": "Foo",
+		"patches": []map[string]any{
+			{"op": "insert_before", "match": "anchor", "code": "log.Println()"},
+		},
+	})
+	require.False(t, result.IsError, resultText(t, result))
+	assert.NotContains(t, resultText(t, result), "HINT:")
+}
+
+// TestDescribeTool_Patch_ListsLimitations asserts that 'describe_tool name=patch'
+// surfaces a Limitations section in text mode covering the three known
+// edge cases (multi-line replacement, tabs/escapes, struct-literal field
+// insertion) along with the recommended workaround.
+func TestDescribeTool_Patch_ListsLimitations(t *testing.T) {
+	cs := setupTest(t, &mockCommands{}, &mockQueries{})
+	result, err := cs.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "describe_tool",
+		Arguments: map[string]any{"name": "patch"},
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	text := resultText(t, result)
+	assert.Contains(t, text, "limitations:")
+	assert.Contains(t, text, "multi-line replacement")
+	assert.Contains(t, text, "tabs/escapes")
+	assert.Contains(t, text, "struct-literal")
+	assert.Contains(t, text, "update object=func")
+
+	// JSON form must also expose the limitations array so non-text clients
+	// can branch on it programmatically.
+	jsonResult, err := cs.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "describe_tool",
+		Arguments: map[string]any{"name": "patch", "format": "json"},
+	})
+	require.NoError(t, err)
+	require.False(t, jsonResult.IsError)
+	require.NotNil(t, jsonResult.StructuredContent)
+	buf, err := json.Marshal(jsonResult.StructuredContent)
+	require.NoError(t, err)
+	var payload struct {
+		Tool struct {
+			Limitations []string `json:"limitations"`
+		} `json:"tool"`
+	}
+	require.NoError(t, json.Unmarshal(buf, &payload))
+	require.GreaterOrEqual(t, len(payload.Tool.Limitations), 3)
+	joined := strings.Join(payload.Tool.Limitations, "\n")
+	assert.Contains(t, joined, "multi-line replacement")
+	assert.Contains(t, joined, "update object=func")
+}
+
+// TestPatchToolDescription_MentionsUpdateFallback asserts the tool's
+// description string itself surfaces the "use update for multi-line edits"
+// guidance — agents that read the tool catalog from listTools() should see
+// it without having to call describe_tool.
+func TestPatchToolDescription_MentionsUpdateFallback(t *testing.T) {
+	cs := setupTest(t, &mockCommands{}, &mockQueries{})
+	listed, err := cs.ListTools(context.Background(), nil)
+	require.NoError(t, err)
+	var patchDescription string
+	for _, tool := range listed.Tools {
+		if tool.Name == "patch" {
+			patchDescription = tool.Description
+			break
+		}
+	}
+	require.NotEmpty(t, patchDescription, "patch tool not registered")
+	assert.Contains(t, patchDescription, "update")
+	assert.Contains(t, patchDescription, "multi-line")
+}

--- a/internal/surgeon/inbound/mcp/patch_tool.go
+++ b/internal/surgeon/inbound/mcp/patch_tool.go
@@ -52,7 +52,7 @@ const patchToolDescription = "Surgical AST-aware editor — one tool for all dec
 	"DOCS: doc on add_field/set_doc accepts multiline text using \\n. " +
 	"INTERFACE ops: add_method, remove_method, rename_method, retype_method, set_doc, embed, remove_embed. " +
 	"FILE patches apply sequentially; scope: all (default), code_only, identifiers_only. " +
-	"DECL targets the value expression of a named const/var; string literal delimiters are preserved automatically."
+	"DECL targets the value expression of a named const/var; string literal delimiters are preserved automatically. WHEN TO USE update INSTEAD: op=replace is a known weak spot for multi-line replacements (issue #3) — if your replacement spans multiple lines, contains tabs/escapes, or you're inserting/replacing fields inside a large struct literal, prefer 'update object=func' (or update object=struct) with the full new declaration. The patch response includes a hint when a replace splice produces a shorter-than-expected result. Call 'describe_tool name=patch' for the full Limitations list."
 
 func registerPatchTool(s *mcp.Server, commands service.SurgeonCommands) {
 	mcp.AddTool(s, &mcp.Tool{
@@ -124,6 +124,10 @@ func handlePatchFunction(ctx context.Context, commands service.SurgeonCommands, 
 	for _, w := range result.Warnings {
 		prefix += "\n  WARNING: " + w
 	}
+	hint := replaceShorterHint(ops)
+	if hint != "" {
+		prefix += "\n  HINT: " + hint
+	}
 	var liftJSON []autoLiftJSON
 	for _, al := range result.AutoLifts {
 		liftJSON = append(liftJSON, autoLiftJSON{
@@ -142,11 +146,11 @@ func handlePatchFunction(ctx context.Context, commands service.SurgeonCommands, 
 	}
 	if result.Diff != "" {
 		res := textResult(prefix + "\n\n" + result.Diff)
-		res.StructuredContent = patchOutput{File: in.File, Identifier: in.Identifier, Applied: result.Applied, Preview: result.Preview, Diff: result.Diff, AddedImports: result.AddedImports, Warnings: result.Warnings, AutoLifts: liftJSON}
+		res.StructuredContent = patchOutput{File: in.File, Identifier: in.Identifier, Applied: result.Applied, Preview: result.Preview, Diff: result.Diff, AddedImports: result.AddedImports, Warnings: result.Warnings, Hint: hint, AutoLifts: liftJSON}
 		return res, nil, nil
 	}
 	res := textResult(prefix)
-	res.StructuredContent = patchOutput{File: in.File, Identifier: in.Identifier, Applied: result.Applied, Preview: result.Preview, AddedImports: result.AddedImports, Warnings: result.Warnings, AutoLifts: liftJSON}
+	res.StructuredContent = patchOutput{File: in.File, Identifier: in.Identifier, Applied: result.Applied, Preview: result.Preview, AddedImports: result.AddedImports, Warnings: result.Warnings, Hint: hint, AutoLifts: liftJSON}
 	return res, nil, nil
 }
 
@@ -295,13 +299,17 @@ func handlePatchFile(ctx context.Context, commands service.SurgeonCommands, in p
 	for _, w := range result.Warnings {
 		prefix += "\n  WARNING: " + w
 	}
+	hint := replaceShorterHintFile(ops)
+	if hint != "" {
+		prefix += "\n  HINT: " + hint
+	}
 	if result.Diff != "" {
 		res := textResult(prefix + "\n\n" + result.Diff)
-		res.StructuredContent = patchFileOutput{File: in.File, Applied: result.Applied, Hits: result.Hits, Preview: result.Preview, Diff: result.Diff, AddedImports: result.AddedImports, Warnings: result.Warnings}
+		res.StructuredContent = patchFileOutput{File: in.File, Applied: result.Applied, Hits: result.Hits, Preview: result.Preview, Diff: result.Diff, AddedImports: result.AddedImports, Warnings: result.Warnings, Hint: hint}
 		return res, nil, nil
 	}
 	res := textResult(prefix)
-	res.StructuredContent = patchFileOutput{File: in.File, Applied: result.Applied, Hits: result.Hits, Preview: result.Preview, AddedImports: result.AddedImports, Warnings: result.Warnings}
+	res.StructuredContent = patchFileOutput{File: in.File, Applied: result.Applied, Hits: result.Hits, Preview: result.Preview, AddedImports: result.AddedImports, Warnings: result.Warnings, Hint: hint}
 	return res, nil, nil
 }
 
@@ -345,12 +353,52 @@ func handlePatchDecl(ctx context.Context, commands service.SurgeonCommands, in p
 	for _, w := range result.Warnings {
 		prefix += "\n  WARNING: " + w
 	}
+	hint := replaceShorterHint(ops)
+	if hint != "" {
+		prefix += "\n  HINT: " + hint
+	}
 	if result.Diff != "" {
 		res := textResult(prefix + "\n\n" + result.Diff)
-		res.StructuredContent = patchOutput{File: in.File, Identifier: in.Identifier, Applied: result.Applied, Preview: result.Preview, Diff: result.Diff, AddedImports: result.AddedImports, Warnings: result.Warnings}
+		res.StructuredContent = patchOutput{File: in.File, Identifier: in.Identifier, Applied: result.Applied, Preview: result.Preview, Diff: result.Diff, AddedImports: result.AddedImports, Warnings: result.Warnings, Hint: hint}
 		return res, nil, nil
 	}
 	res := textResult(prefix)
-	res.StructuredContent = patchOutput{File: in.File, Identifier: in.Identifier, Applied: result.Applied, Preview: result.Preview, AddedImports: result.AddedImports, Warnings: result.Warnings}
+	res.StructuredContent = patchOutput{File: in.File, Identifier: in.Identifier, Applied: result.Applied, Preview: result.Preview, AddedImports: result.AddedImports, Warnings: result.Warnings, Hint: hint}
 	return res, nil, nil
+}
+
+// replaceShorterHint scans the supplied patches for op=replace ops whose
+// replacement text is shorter than the matched text. When at least one such
+// op is present, it returns the agent-facing hint string that points to
+// 'update object=func' as the recommended workaround for the multi-line
+// replacement edge case tracked by issue #3. Returns "" when no shrinking
+// replace is detected.
+func replaceShorterHint(ops []patchOpInput) string {
+	for _, p := range ops {
+		if p.Op != "replace" {
+			continue
+		}
+		if p.Match == "" {
+			continue
+		}
+		if len(p.Replace) < len(p.Match) {
+			return "replacement applied but result is shorter than input — try update object=func for whole-declaration rewrites (see describe_tool name=patch for the full Limitations list)"
+		}
+	}
+	return ""
+}
+
+// replaceShorterHintFile is the patch_file (whole-file substitution)
+// counterpart of replaceShorterHint. It inspects the file-level patches and
+// flags the same shrinking-replace pattern that motivates the update fallback.
+func replaceShorterHintFile(ops []filePatchOpInput) string {
+	for _, p := range ops {
+		if p.Match == "" {
+			continue
+		}
+		if len(p.Replace) < len(p.Match) {
+			return "replacement applied but result is shorter than input — try update object=func for whole-declaration rewrites (see describe_tool name=patch for the full Limitations list)"
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
## Summary

Closes #5. Improves discoverability of `update object=func` as the recommended fallback when `patch op=replace` misbehaves on multi-line edits (the silent-data-loss bug tracked separately by #3).

Three sub-fixes:

1. **`patch` tool description** now ends with a "WHEN TO USE update INSTEAD" sentence pointing at `update object=func` / `update object=struct` for multi-line replacements, tab/escape-bearing replacements, and large struct-literal field insertions. Agents that only read `tools/list` see this without needing `describe_tool`.

2. **Structured patch response** carries a new `hint` field (added to both `patchOutput` and `patchFileOutput`). When a user supplies `op=replace` with `len(replace) < len(match)`, the handlers for `target=function`, `target=decl`, and `target=file` attach the hint `"replacement applied but result is shorter than input - try update object=func for whole-declaration rewrites (see describe_tool name=patch for the full Limitations list)"` to both the text content (rendered as a `HINT:` line) and the JSON `hint` field. The operation still applies; the hint is purely informational.

3. **`describe_tool name=patch`** now lists a `limitations:` section enumerating the three known edge cases (multi-line replacement, tabs/escapes in replacement text, large struct-literal field insertion), each with the same `update object=func` workaround. The limitations are exposed both in the text output and in the JSON `limitations` field of `toolEntryOut`.

A new `toolEntry.Limitations []string` field lets future tools surface their own limitations the same way.

## Files changed

- `internal/surgeon/inbound/mcp/patch_tool.go` - description constant + hint plumbing in handlers + new helpers
- `internal/surgeon/inbound/mcp/helpers.go` - `Hint string` on the two structured outputs
- `internal/surgeon/inbound/mcp/describe_tool.go` - `Limitations []string` on `toolEntry` and `toolEntryOut`, render block, populated patch entry
- `internal/surgeon/inbound/mcp/patch_hint_test.go` (new) - 7 tests covering the hint trigger, the no-trigger path, the describe_tool limitations rendering (text + JSON), and the tool description content

## Test plan

- [x] `go test ./...` - all packages green (`ok internal/surgeon/inbound/mcp`)
- [x] `go test -run TestPatch_|TestDescribeTool_Patch_|TestPatchToolDescription_` - 7/7 new tests pass
- [x] `go build ./...` (via build_check) - green
- [x] Pre-push hook (tests + golangci-lint) - 0 issues
