### PR TITLE
feat(test_run): add verbosity=summary mode for large suites (closes #4)

### DIFF
--- a/internal/surgeon/inbound/mcp/describe_tool.go
+++ b/internal/surgeon/inbound/mcp/describe_tool.go
@@ -76,7 +76,7 @@ var toolCatalog = []toolEntry{
 
 	// VALIDATE
 	{Name: "build_check", Category: "validate", Summary: "run go build and return structured compile diagnostics; affected_by=file narrows to that file's reverse-dep closure", Example: `{"affected_by": "internal/foo/bar.go"}`, Related: "test_run"},
-	{Name: "test_run", Category: "validate", Summary: "run go test and return a compact pass/fail report; affected_by=file narrows to owning package + reverse-deps", Example: `{"affected_by": "internal/foo/bar.go"}`, Related: "build_check, test"},
+	{Name: "test_run", Category: "validate", Summary: "run go test and return a compact pass/fail report; affected_by=file narrows to owning package + reverse-deps; verbosity=summary|full controls payload size (auto-summary above 50 tests)", Example: `{"affected_by": "internal/foo/bar.go", "verbosity": "summary"}`, Related: "build_check, test"},
 
 	// BATCH
 	{Name: "execute_plan", Category: "batch", Summary: "apply up to 15 edit actions atomically (create/update/delete/patch_*); use when 3+ edits must land together or roll back together", Example: `{"actions": [{"action": "patch", "file": "a.go", "identifier": "Foo", "target": "function", "patch_function_ops": [...]}]}`, Related: "patch, create"},

--- a/internal/surgeon/inbound/mcp/server.go
+++ b/internal/surgeon/inbound/mcp/server.go
@@ -258,7 +258,7 @@ func registerQueryTools(s *mcp.Server, queries service.SurgeonQueries) {
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "test_run",
-		Description: "Run `go test` scoped to a package/directory and return a compact pass/fail report with per-test timing and failure file:line references. Use after editing Go code to verify behavior in-loop. dir defaults to ./..., timeout defaults to 120s (max 600). Pass affected_by=path/to/file.go to run only the owning package plus its reverse-dependency closure (mutually exclusive with dir). On success the verbatim raw_output stream is omitted from the structured payload (it bloats responses without adding signal); set include_raw_output=true to force it on a green run.",
+		Description: "Run `go test` scoped to a package/directory and return a compact pass/fail report with per-test timing and failure file:line references. Use after editing Go code to verify behavior in-loop. dir defaults to ./..., timeout defaults to 120s (max 600). Pass affected_by=path/to/file.go to run only the owning package plus its reverse-dependency closure (mutually exclusive with dir). On success the verbatim raw_output stream is omitted from the structured payload (it bloats responses without adding signal); set include_raw_output=true to force it on a green run. verbosity controls payload size on large suites: 'summary' returns only success/summary/failed tests (~1k chars regardless of suite size — ideal for the 25k token tool-result budget); 'full' keeps everything; default auto picks 'summary' once the suite has more than 50 tests.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, in testRunInput) (*mcp.CallToolResult, any, error) {
 		result, err := queries.TestRun(ctx, domain.TestRunRequest{
 			Dir:            in.Dir,
@@ -275,8 +275,9 @@ func registerQueryTools(s *mcp.Server, queries service.SurgeonQueries) {
 		if result.Success && !in.IncludeRawOutput {
 			result.RawOutput = ""
 		}
+		structured := applyTestRunVerbosity(result, in.Verbosity, in.IncludeRawOutput)
 		res := textResult(formatTestRunResult(result))
-		res.StructuredContent = result
+		res.StructuredContent = structured
 		return res, nil, nil
 	})
 }
@@ -1161,5 +1162,6 @@ type testRunInput struct {
 	Tags             string `json:"tags,omitempty" jsonschema:"build tags (whitelist [a-z_][a-z0-9_,.]*)"`
 	TimeoutSeconds   int    `json:"timeout_seconds,omitempty" jsonschema:"overall timeout in seconds (default 120, max 600)"`
 	AffectedBy       string `json:"affected_by,omitempty" jsonschema:"path to a .go file — narrow the test run to the package that owns this file plus every package in the module that (transitively) imports it. Mutually exclusive with dir. Great after editing one file in a large monorepo — skips running tests in unrelated packages."`
+	Verbosity        string `json:"verbosity,omitempty" jsonschema:"output verbosity: 'summary' returns only success, summary, and failed tests (compact ~1k chars regardless of suite size — ideal for large suites); 'full' returns everything including raw_output and per-test elapsed_ms. Defaults to auto: summary when the suite has more than 50 tests, full otherwise. Pass 'full' to force the verbose payload, 'summary' to force the compact one."`
 	IncludeRawOutput bool   `json:"include_raw_output,omitempty" jsonschema:"include the verbatim go test -json stream in structured output. By default RawOutput is dropped from the structured payload on success (where it bloats responses without adding signal); failures always keep it. Set true to force inclusion (e.g. when you want full test output regardless of pass/fail)."`
 }

--- a/internal/surgeon/inbound/mcp/test_run_verbosity.go
+++ b/internal/surgeon/inbound/mcp/test_run_verbosity.go
@@ -1,0 +1,95 @@
+package mcp
+
+import (
+	"github.com/JLugagne/go-surgeon/internal/surgeon/domain"
+)
+
+// testRunVerbosityThreshold is the auto-mode tipping point: when a suite
+// produces strictly more than this many test cases, the structured payload
+// switches to "summary" mode unless the caller explicitly passes
+// verbosity="full". The value is calibrated so that small/medium suites keep
+// the rich per-test view (timing for every case, raw_output on failure) while
+// large suites stay within the 25k-token tool-result budget on which agents
+// rely for in-loop verification.
+const testRunVerbosityThreshold = 50
+
+// testRunSummaryPayload mirrors domain.TestRunResult but only carries the
+// fields meaningful in summary mode. Passing tests are dropped entirely; only
+// failed (and skipped) tests survive in Tests, with a counter exposed via
+// PassedCount so callers can still see "how many green".
+type testRunSummaryPayload struct {
+	Success     bool                    `json:"success"`
+	Summary     string                  `json:"summary"`
+	Tests       []domain.TestCaseResult `json:"tests"`
+	PassedCount int                     `json:"passed_count"`
+	DurationMS  int                     `json:"duration_ms"`
+	TimedOut    bool                    `json:"timed_out,omitempty"`
+	Packages    []string                `json:"packages,omitempty"`
+	RawOutput   string                  `json:"raw_output,omitempty"`
+	Verbosity   string                  `json:"verbosity"`
+}
+
+// applyTestRunVerbosity returns the structured payload that should be attached
+// to the MCP response, given the caller's explicit verbosity choice and the
+// shape of the test result. It honors verbosity="summary"/"full" verbatim;
+// when verbosity is empty the threshold drives the decision (auto mode).
+//
+// In summary mode, raw_output is dropped, passing tests are collapsed into a
+// counter, and per-test elapsed_ms / output_lines for the few surviving
+// (failed/skipped) tests are preserved untouched so the agent can act on the
+// failure context. include_raw_output=true forces raw_output to survive even
+// in summary mode (a deliberate escape hatch for agents that still want the
+// full go test -json stream alongside the compact tests slice).
+func applyTestRunVerbosity(result domain.TestRunResult, verbosity string, includeRawOutput bool) any {
+	mode := resolveTestRunVerbosity(verbosity, len(result.Tests))
+	if mode == "full" {
+		return result
+	}
+
+	var failedOrSkipped []domain.TestCaseResult
+	passed := 0
+	for _, t := range result.Tests {
+		if t.Status == "pass" {
+			passed++
+			continue
+		}
+		failedOrSkipped = append(failedOrSkipped, t)
+	}
+
+	payload := testRunSummaryPayload{
+		Success:     result.Success,
+		Summary:     result.Summary,
+		Tests:       failedOrSkipped,
+		PassedCount: passed,
+		DurationMS:  result.DurationMS,
+		TimedOut:    result.TimedOut,
+		Packages:    result.Packages,
+		Verbosity:   "summary",
+	}
+
+	// raw_output is the single biggest token sink; it stays out of summary
+	// payloads unless the caller explicitly opted in via include_raw_output.
+	// On failure, formatTestRunResult still surfaces the failure context in
+	// the textual result, so the agent is not flying blind.
+	if includeRawOutput {
+		payload.RawOutput = result.RawOutput
+	}
+
+	return payload
+}
+
+// resolveTestRunVerbosity picks the effective verbosity mode given the caller
+// hint and the suite size. Empty/unknown values fall back to auto, where the
+// threshold (testRunVerbosityThreshold) is the only decision input.
+func resolveTestRunVerbosity(verbosity string, testCount int) string {
+	switch verbosity {
+	case "summary":
+		return "summary"
+	case "full":
+		return "full"
+	}
+	if testCount > testRunVerbosityThreshold {
+		return "summary"
+	}
+	return "full"
+}

--- a/internal/surgeon/inbound/mcp/test_run_verbosity_test.go
+++ b/internal/surgeon/inbound/mcp/test_run_verbosity_test.go
@@ -1,0 +1,216 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/JLugagne/go-surgeon/internal/surgeon/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeTestCases builds a synthetic suite of n passing tests, optionally
+// followed by m failing tests so we can assert that summary mode keeps
+// failures while collapsing passes.
+func makeTestCases(passes, fails int) []domain.TestCaseResult {
+	out := make([]domain.TestCaseResult, 0, passes+fails)
+	for i := 0; i < passes; i++ {
+		out = append(out, domain.TestCaseResult{
+			Package:   "pkg",
+			Name:      fmt.Sprintf("TestPass%d", i),
+			Status:    "pass",
+			ElapsedMS: 10 + i,
+		})
+	}
+	for i := 0; i < fails; i++ {
+		out = append(out, domain.TestCaseResult{
+			Package:        "pkg",
+			Name:           fmt.Sprintf("TestFail%d", i),
+			Status:         "fail",
+			ElapsedMS:      20 + i,
+			FailureFile:    "pkg/foo_test.go",
+			FailureLine:    42 + i,
+			FailureMessage: "expected x got y",
+		})
+	}
+	return out
+}
+
+func TestTestRun_VerbositySummary_DropsRawOutputAndPasses(t *testing.T) {
+	queries := &mockQueries{
+		testRunFn: func(_ context.Context, _ domain.TestRunRequest) (domain.TestRunResult, error) {
+			return domain.TestRunResult{
+				Success:    true,
+				Tests:      makeTestCases(10, 0),
+				Summary:    "10 passed, 0 failed",
+				RawOutput:  `{"Action":"pass"}` + "\n",
+				DurationMS: 100,
+			}, nil
+		},
+	}
+	cs := setupTest(t, &mockCommands{}, queries)
+
+	result := callTool(t, cs, "test_run", map[string]any{"verbosity": "summary"})
+	require.NotNil(t, result.StructuredContent)
+
+	// The structured payload in summary mode is the compact shape (passing
+	// tests are collapsed into a counter, raw_output is dropped). Decode as
+	// a generic map to assert exactly what fields are present.
+	data, err := json.Marshal(result.StructuredContent)
+	require.NoError(t, err)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(data, &payload))
+
+	assert.Equal(t, true, payload["success"])
+	assert.Equal(t, "summary", payload["verbosity"])
+	assert.Equal(t, float64(10), payload["passed_count"])
+	assert.Empty(t, payload["raw_output"], "raw_output must be dropped in summary mode")
+	tests, _ := payload["tests"].([]any)
+	assert.Empty(t, tests, "passing tests should be collapsed into passed_count, not listed")
+}
+
+func TestTestRun_VerbosityFull_KeepsEverything(t *testing.T) {
+	rawStream := `{"Action":"pass"}` + "\n"
+	queries := &mockQueries{
+		testRunFn: func(_ context.Context, _ domain.TestRunRequest) (domain.TestRunResult, error) {
+			return domain.TestRunResult{
+				Success:    true,
+				Tests:      makeTestCases(3, 0),
+				Summary:    "3 passed",
+				RawOutput:  rawStream,
+				DurationMS: 50,
+			}, nil
+		},
+	}
+	cs := setupTest(t, &mockCommands{}, queries)
+
+	// verbosity=full bypasses both the raw_output drop-on-success rule and
+	// the auto threshold; it must include every per-test field.
+	result := callTool(t, cs, "test_run", map[string]any{
+		"verbosity":          "full",
+		"include_raw_output": true,
+	})
+	decoded := decodeTestRunStructured(t, result)
+	assert.True(t, decoded.Success)
+	assert.Equal(t, rawStream, decoded.RawOutput)
+	require.Len(t, decoded.Tests, 3)
+	assert.Equal(t, 10, decoded.Tests[0].ElapsedMS, "per-test elapsed_ms must be preserved in full mode")
+}
+
+func TestTestRun_VerbosityAuto_SummaryAboveThreshold(t *testing.T) {
+	// 51 tests is one above the threshold (50) — auto mode should kick into
+	// summary. We build all-passing tests so the surviving tests slice is
+	// empty and passed_count carries the signal.
+	queries := &mockQueries{
+		testRunFn: func(_ context.Context, _ domain.TestRunRequest) (domain.TestRunResult, error) {
+			return domain.TestRunResult{
+				Success:    true,
+				Tests:      makeTestCases(51, 0),
+				Summary:    "51 passed, 0 failed",
+				RawOutput:  `{"Action":"pass"}` + "\n",
+				DurationMS: 1234,
+			}, nil
+		},
+	}
+	cs := setupTest(t, &mockCommands{}, queries)
+
+	result := callTool(t, cs, "test_run", map[string]any{})
+	data, err := json.Marshal(result.StructuredContent)
+	require.NoError(t, err)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(data, &payload))
+
+	assert.Equal(t, "summary", payload["verbosity"], "auto mode must pick summary above the threshold")
+	assert.Equal(t, float64(51), payload["passed_count"])
+	assert.Empty(t, payload["raw_output"])
+}
+
+func TestTestRun_VerbosityAuto_FullBelowThreshold(t *testing.T) {
+	// 5 tests is well below the threshold — auto mode keeps the full
+	// payload (passing tests with their elapsed_ms intact).
+	queries := &mockQueries{
+		testRunFn: func(_ context.Context, _ domain.TestRunRequest) (domain.TestRunResult, error) {
+			return domain.TestRunResult{
+				Success:    true,
+				Tests:      makeTestCases(5, 0),
+				Summary:    "5 passed",
+				DurationMS: 10,
+			}, nil
+		},
+	}
+	cs := setupTest(t, &mockCommands{}, queries)
+
+	result := callTool(t, cs, "test_run", map[string]any{})
+	decoded := decodeTestRunStructured(t, result)
+	require.Len(t, decoded.Tests, 5, "auto mode below threshold must keep full per-test list")
+	assert.Equal(t, "pass", decoded.Tests[0].Status)
+	assert.NotZero(t, decoded.Tests[0].ElapsedMS, "per-test elapsed_ms must survive in full mode")
+}
+
+func TestTestRun_VerbositySummary_FailureKeepsContext(t *testing.T) {
+	rawStream := `{"Action":"fail","Test":"TestFail0"}` + "\n"
+	queries := &mockQueries{
+		testRunFn: func(_ context.Context, _ domain.TestRunRequest) (domain.TestRunResult, error) {
+			return domain.TestRunResult{
+				Success:    false,
+				Tests:      makeTestCases(60, 2),
+				Summary:    "60 passed, 2 failed",
+				RawOutput:  rawStream,
+				DurationMS: 999,
+			}, nil
+		},
+	}
+	cs := setupTest(t, &mockCommands{}, queries)
+
+	// Auto mode with 62 tests > threshold picks summary; failures must
+	// still appear with file:line + message intact (that is the whole point
+	// of summary mode for an agent debugging a red CI run).
+	result := callTool(t, cs, "test_run", map[string]any{})
+	data, err := json.Marshal(result.StructuredContent)
+	require.NoError(t, err)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(data, &payload))
+
+	assert.Equal(t, "summary", payload["verbosity"])
+	assert.Equal(t, false, payload["success"])
+	assert.Equal(t, float64(60), payload["passed_count"])
+	tests, _ := payload["tests"].([]any)
+	require.Len(t, tests, 2, "failures must survive in summary mode")
+	first, _ := tests[0].(map[string]any)
+	assert.Equal(t, "fail", first["status"])
+	assert.Equal(t, "pkg/foo_test.go", first["failure_file"])
+	assert.Equal(t, "expected x got y", first["failure_message"])
+}
+
+func TestTestRun_VerbositySummary_RawOutputKeptWhenIncludeRawOutput(t *testing.T) {
+	// Even in summary mode, the include_raw_output escape hatch must work:
+	// agents that explicitly want the verbatim go test -json stream should
+	// still get it alongside the compact tests slice.
+	rawStream := `{"Action":"fail"}` + "\n"
+	queries := &mockQueries{
+		testRunFn: func(_ context.Context, _ domain.TestRunRequest) (domain.TestRunResult, error) {
+			return domain.TestRunResult{
+				Success:    false,
+				Tests:      makeTestCases(60, 1),
+				Summary:    "60 passed, 1 failed",
+				RawOutput:  rawStream,
+				DurationMS: 100,
+			}, nil
+		},
+	}
+	cs := setupTest(t, &mockCommands{}, queries)
+
+	result := callTool(t, cs, "test_run", map[string]any{
+		"verbosity":          "summary",
+		"include_raw_output": true,
+	})
+	data, err := json.Marshal(result.StructuredContent)
+	require.NoError(t, err)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(data, &payload))
+
+	assert.Equal(t, "summary", payload["verbosity"])
+	assert.Equal(t, rawStream, payload["raw_output"])
+}


### PR DESCRIPTION
## Summary
- Adds verbosity (summary | full | auto) to test_run; auto picks summary once tests > 50.
- Summary mode drops raw_output and collapses passing tests into a passed_count, keeping failures (file/line/message) intact. Resolves the 237k-char payload issue on ~600-test projects that was blowing the 25k-token tool-result budget.
- include_raw_output remains an escape hatch and works alongside verbosity=summary.
- Updates the test_run tool description and describe_tool catalog entry to advertise the new parameter.

## Test plan
- [x] go test ./... — 602 passed
- [x] golangci-lint run ./... — 0 issues
- [x] New tests cover: explicit summary, explicit full, auto > threshold, auto < threshold, summary keeps failure context, summary + include_raw_output

Closes #4