### PR TITLE
fix(patch): validate op=replace result and roll back on mismatch (closes #3)

### DIFF
--- a/internal/surgeon/app/commands/patch_decl.go
+++ b/internal/surgeon/app/commands/patch_decl.go
@@ -62,6 +62,9 @@ func (h *ExecutePlanHandler) PatchDecl(ctx context.Context, req domain.PatchDecl
 	}
 	edits := make([]resolvedEdit, len(req.Patches))
 	var errs []string
+	// Issue #3: track resolved replacements so we can verify post-splice that
+	// each op=replace's text actually landed in the new file.
+	var replaceChecks []replaceValidation
 
 	for i, p := range req.Patches {
 		lineMode := p.AtLine > 0 || p.FromLine > 0 || p.ToLine > 0
@@ -96,6 +99,9 @@ func (h *ExecutePlanHandler) PatchDecl(ctx context.Context, req domain.PatchDecl
 			}
 			ls, le, lrepl := buildLineModeEdit(p, origBody, start, end)
 			edits[i] = resolvedEdit{start: ls, end: le, replacement: lrepl}
+			if p.Op == domain.PatchOpReplace {
+				replaceChecks = append(replaceChecks, replaceValidation{Index: i + 1, Replacement: lrepl})
+			}
 			continue
 		}
 
@@ -185,6 +191,7 @@ func (h *ExecutePlanHandler) PatchDecl(ctx context.Context, req domain.PatchDecl
 				}
 			}
 			edits[i] = resolvedEdit{start: hit[0], end: hit[1], replacement: repl}
+			replaceChecks = append(replaceChecks, replaceValidation{Index: i + 1, Replacement: repl})
 
 		case domain.PatchOpInsertBefore:
 			indent := lineIndent(origBody, hit[0])
@@ -256,6 +263,12 @@ func (h *ExecutePlanHandler) PatchDecl(ctx context.Context, req domain.PatchDecl
 
 	if err := validateGoSource(req.FilePath, newSrc); err != nil {
 		return domain.PatchDeclResult{}, err
+	}
+	// Issue #3 guard: ensure every op=replace patch's text is actually
+	// present in the assembled source — protect against silent data loss
+	// when a multi-line replacement is mangled in transport.
+	if vErr := validateReplaceApplied(newSrc, replaceChecks); vErr != nil {
+		return domain.PatchDeclResult{}, vErr
 	}
 
 	diff := diffStrings(req.FilePath, string(src), string(newSrc))

--- a/internal/surgeon/app/commands/patch_file.go
+++ b/internal/surgeon/app/commands/patch_file.go
@@ -204,6 +204,17 @@ func (h *ExecutePlanHandler) PatchFile(ctx context.Context, req domain.PatchFile
 		filteredLines := formatFilteredLines(working, filtered)
 		if len(accepted) > 0 {
 			working = applyRangeReplacements(working, accepted, replaces)
+			// Issue #3 guard: validate THIS patch's replacement landed before
+			// subsequent patches mutate the working source. Sequential patches
+			// may legitimately rewrite an earlier replacement (e.g. "a"->"b"
+			// then "b"->"c"), so we cannot defer the check to the final source.
+			perPatch := make([]replaceValidation, 0, len(replaces))
+			for _, r := range replaces {
+				perPatch = append(perPatch, replaceValidation{Index: i + 1, Replacement: r})
+			}
+			if vErr := validateReplaceApplied([]byte(working), perPatch); vErr != nil {
+				return domain.PatchFileResult{}, vErr
+			}
 		}
 
 		switch {
@@ -238,6 +249,11 @@ func (h *ExecutePlanHandler) PatchFile(ctx context.Context, req domain.PatchFile
 	if dirErr := checkDirectivesIntact(formatted, req.FilePath); dirErr != nil {
 		return domain.PatchFileResult{}, dirErr
 	}
+	// Issue #3 guard: per-patch validation that each replacement landed in
+	// `working` already happened inside the patch loop above; sequential
+	// patches may legitimately overwrite earlier replacements so the check
+	// is local to each step rather than against the final source.
+
 	diff := diffStrings(req.FilePath, string(src), string(formatted))
 
 	if req.Preview {

--- a/internal/surgeon/app/commands/patch_function.go
+++ b/internal/surgeon/app/commands/patch_function.go
@@ -162,6 +162,10 @@ func (h *ExecutePlanHandler) PatchFunction(ctx context.Context, req domain.Patch
 	var extraEdits []resolvedEdit
 	var sigEdits []signatureEdit
 	var errs []string
+	// replaceChecks accumulates the resolved replacement text for every
+	// op=replace patch so we can verify post-splice that the replacement
+	// actually landed in newSrc (issue #3 — silent data loss guard).
+	var replaceChecks []replaceValidation
 
 	type afterFuncEdit struct {
 		code string
@@ -243,6 +247,9 @@ func (h *ExecutePlanHandler) PatchFunction(ctx context.Context, req domain.Patch
 			}
 			ls, le, lrepl := buildLineModeEdit(p, origBody, start, end)
 			edits[i] = resolvedEdit{start: ls, end: le, replacement: lrepl}
+			if p.Op == domain.PatchOpReplace {
+				replaceChecks = append(replaceChecks, replaceValidation{Index: i + 1, Replacement: lrepl})
+			}
 			continue
 		}
 		var hits [][2]int // [start, end] byte ranges in origBody
@@ -307,6 +314,7 @@ func (h *ExecutePlanHandler) PatchFunction(ctx context.Context, req domain.Patch
 						}
 					}
 					extraEdits = append(extraEdits, resolvedEdit{start: h[0], end: h[1], replacement: repl})
+					replaceChecks = append(replaceChecks, replaceValidation{Index: i + 1, Replacement: repl})
 				case domain.PatchOpDelete:
 					start, end := deletionRange(origBody, h[0], h[1])
 					extraEdits = append(extraEdits, resolvedEdit{start: start, end: end, replacement: ""})
@@ -423,6 +431,7 @@ func (h *ExecutePlanHandler) PatchFunction(ctx context.Context, req domain.Patch
 				}
 			}
 			edits[i] = resolvedEdit{start: hit[0], end: hit[1], replacement: repl}
+			replaceChecks = append(replaceChecks, replaceValidation{Index: i + 1, Replacement: repl})
 
 		case domain.PatchOpInsertBefore, domain.PatchOpInsertAfter:
 			plan := resolveInsertAnchor(fset, targetFn, origBody, lbraceOff+1, bodyStartLine, i+1, p.Op, p.Code, hit[0])
@@ -554,6 +563,13 @@ func (h *ExecutePlanHandler) PatchFunction(ctx context.Context, req domain.Patch
 	}
 	if dirErr := checkDirectivesIntact(newSrc, req.FilePath); dirErr != nil {
 		return domain.PatchFunctionResult{}, dirErr
+	}
+	// Issue #3 guard: confirm every op=replace patch's text is present in
+	// the assembled source. If a multi-line replacement was mangled in
+	// transport and the splice removed the match without inserting the
+	// payload, fail loudly instead of writing corrupted bytes.
+	if vErr := validateReplaceApplied(newSrc, replaceChecks); vErr != nil {
+		return domain.PatchFunctionResult{}, vErr
 	}
 
 	diff := diffStrings(req.FilePath, string(src), string(newSrc))

--- a/internal/surgeon/app/commands/patch_function_test.go
+++ b/internal/surgeon/app/commands/patch_function_test.go
@@ -2325,3 +2325,72 @@ func Foo() {
 	assert.NotContains(t, content, "bar()")
 	assert.Equal(t, 2, strings.Count(content, "baz()"))
 }
+
+// TestPatchFunction_Issue3_MultiLineFunctionBodyRewrite reproduces case #1
+// from issue #3: a function body rewrite where the replacement spans
+// multiple lines. After the fix this must succeed cleanly — applied=1, the
+// replacement text is present in the result, and no validation error fires.
+func TestPatchFunction_Issue3_MultiLineFunctionBodyRewrite(t *testing.T) {
+	ctx := context.Background()
+	h, fs := newPatchHandler()
+	setFile(fs, "f.go", `package p
+
+func ProcessOrder(id int) error {
+	if id <= 0 {
+		return fmt.Errorf("bad id")
+	}
+	return nil
+}
+`)
+
+	multiLineMatch := "if id <= 0 {\n\t\treturn fmt.Errorf(\"bad id\")\n\t}"
+	multiLineReplace := "if id <= 0 {\n\t\treturn fmt.Errorf(\"order id must be positive, got %d\", id)\n\t}\n\tif id > 1_000_000 {\n\t\treturn fmt.Errorf(\"order id %d is out of supported range\", id)\n\t}"
+
+	res, err := h.PatchFunction(ctx, domain.PatchFunctionRequest{
+		FilePath:   "f.go",
+		Identifier: "ProcessOrder",
+		Patches: []domain.FunctionPatch{
+			{Op: domain.PatchOpReplace, Match: multiLineMatch, Replace: multiLineReplace},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Applied)
+	content := getFile(fs, "f.go")
+	assert.Contains(t, content, "order id must be positive")
+	assert.Contains(t, content, "out of supported range")
+}
+
+// TestPatchFunction_Issue3_StructLiteralFieldInsertion reproduces case #2
+// from issue #3: inserting a new field into a struct literal inside a
+// function body via a multi-line op=replace. The replacement is a literal
+// struct-literal block. The validation must accept it (not fire a
+// PATCH_REPLACE_NOT_APPLIED) and the resulting file must contain the new
+// field.
+func TestPatchFunction_Issue3_StructLiteralFieldInsertion(t *testing.T) {
+	ctx := context.Background()
+	h, fs := newPatchHandler()
+	setFile(fs, "main.go", `package main
+
+func build() Backends {
+	return Backends{
+		Postgres: pool,
+	}
+}
+`)
+
+	matchText := "Backends{\n\t\tPostgres: pool,\n\t}"
+	replaceText := "Backends{\n\t\tPostgres: pool,\n\t\tKafka:    kafkaBackend,\n\t}"
+
+	res, err := h.PatchFunction(ctx, domain.PatchFunctionRequest{
+		FilePath:   "main.go",
+		Identifier: "build",
+		Patches: []domain.FunctionPatch{
+			{Op: domain.PatchOpReplace, Match: matchText, Replace: replaceText},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Applied)
+	content := getFile(fs, "main.go")
+	assert.Contains(t, content, "Kafka:    kafkaBackend")
+	assert.Contains(t, content, "Postgres: pool")
+}

--- a/internal/surgeon/app/commands/patch_replace_validate.go
+++ b/internal/surgeon/app/commands/patch_replace_validate.go
@@ -1,0 +1,91 @@
+// validateReplaceApplied verifies that, after a text-splice patch has been
+// computed, every op=replace patch's replacement text is actually present in
+// the resulting source. This is a paranoid post-condition check that guards
+// against silent data loss when an upstream serialization bug — for example
+// a multi-line replacement being mishandled inside a nested array — causes
+// the splice to remove the matched text without inserting the replacement.
+//
+// The helper compares the literal bytes of each replacement against the
+// resulting source. When a replacement is non-empty but absent from the
+// result, it returns a structured error so the caller can roll back the
+// write. Trailing/leading whitespace differences are tolerated by trimming
+// before comparison: callers (patch_function, patch_decl) sometimes
+// re-indent or normalize the replacement, so we look for the trimmed
+// payload as a substring rather than the exact bytes.
+//
+// Returns nil when every non-empty replacement is found, or when the
+// replacements list is empty (nothing to validate).
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/JLugagne/go-surgeon/internal/surgeon/domain"
+)
+
+// replaceValidation describes one replacement to verify after the splice.
+// Index is the 1-based patch index used in error messages so the agent can
+// pinpoint which patch in the array did not land. Replacement holds the
+// literal text the splice was supposed to insert.
+type replaceValidation struct {
+	Index       int
+	Replacement string
+}
+
+// validateReplaceApplied checks every entry in replacements against newSrc.
+// It returns nil if all non-empty replacements are present (substring
+// match after whitespace trimming). Otherwise it returns a domain.Error
+// with code PATCH_REPLACE_NOT_APPLIED and a message that names the
+// offending patch index plus a truncated preview of the missing text.
+//
+// Empty replacements are skipped: an op=replace with replace="" is a
+// legal "delete the match" pattern and there is nothing textual to
+// verify post-splice.
+func validateReplaceApplied(newSrc []byte, replacements []replaceValidation) error {
+	if len(replacements) == 0 {
+		return nil
+	}
+	src := string(newSrc)
+	for _, rv := range replacements {
+		needle := strings.TrimSpace(rv.Replacement)
+		if needle == "" {
+			continue
+		}
+		if strings.Contains(src, needle) {
+			continue
+		}
+		return &domain.Error{
+			Code:    "PATCH_REPLACE_NOT_APPLIED",
+			Message: formatReplaceNotAppliedMessage(rv.Index, rv.Replacement),
+		}
+	}
+	return nil
+}
+
+// formatReplaceNotAppliedMessage builds the agent-facing error text shown
+// when a replacement disappears between resolution and the final source.
+// The replacement is truncated to keep the message short while still
+// giving the agent enough to recognize what went missing.
+func formatReplaceNotAppliedMessage(index int, replacement string) string {
+	preview := truncateReplacementPreview(replacement, 120)
+	return fmt.Sprintf(
+		"patch #%d (replace): result file does not contain the replacement text — write rolled back to prevent silent data loss. "+
+			"Expected file to contain %q after splice but it does not. "+
+			"This usually means the replacement was mangled in transport (a known multi-line/JSON-array client bug) — retry the call, "+
+			"or fall back to update object=func / update object=file for whole-declaration rewrites.",
+		index, preview,
+	)
+}
+
+// truncateReplacementPreview returns at most max runes of s, appending an
+// ellipsis when the input was shortened. Newlines are collapsed to "\\n"
+// so the preview fits on a single line in the error message.
+func truncateReplacementPreview(s string, max int) string {
+	flat := strings.ReplaceAll(s, "\n", "\\n")
+	if len([]rune(flat)) <= max {
+		return flat
+	}
+	r := []rune(flat)
+	return string(r[:max]) + "..."
+}

--- a/internal/surgeon/app/commands/patch_replace_validate_test.go
+++ b/internal/surgeon/app/commands/patch_replace_validate_test.go
@@ -1,0 +1,162 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateReplaceApplied_HappyPath_PresentSubstring(t *testing.T) {
+	src := []byte(`package p
+
+func F() string {
+	return "hello world"
+}
+`)
+	checks := []replaceValidation{
+		{Index: 1, Replacement: `"hello world"`},
+	}
+	if err := validateReplaceApplied(src, checks); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestValidateReplaceApplied_HappyPath_MultiLineReplacement(t *testing.T) {
+	src := []byte(`package p
+
+func F() error {
+	if x == 1 {
+		return errors.New("a")
+	}
+	return nil
+}
+`)
+	checks := []replaceValidation{
+		{Index: 2, Replacement: "if x == 1 {\n\t\treturn errors.New(\"a\")\n\t}"},
+	}
+	if err := validateReplaceApplied(src, checks); err != nil {
+		t.Fatalf("multi-line replacement should validate when present: %v", err)
+	}
+}
+
+func TestValidateReplaceApplied_HappyPath_EmptyReplacementSkipped(t *testing.T) {
+	src := []byte(`package p
+`)
+	checks := []replaceValidation{
+		{Index: 1, Replacement: ""},
+	}
+	if err := validateReplaceApplied(src, checks); err != nil {
+		t.Fatalf("empty replacement must be a no-op: %v", err)
+	}
+}
+
+func TestValidateReplaceApplied_HappyPath_WhitespaceTolerant(t *testing.T) {
+	src := []byte(`package p
+
+func F() {
+	doWork()
+}
+`)
+	// Replacement supplied with leading and trailing whitespace; the trimmed
+	// payload is in the file, so validation must still pass.
+	checks := []replaceValidation{
+		{Index: 1, Replacement: "\n\tdoWork()\n"},
+	}
+	if err := validateReplaceApplied(src, checks); err != nil {
+		t.Fatalf("trimmed substring match should pass: %v", err)
+	}
+}
+
+func TestValidateReplaceApplied_NilChecks(t *testing.T) {
+	src := []byte("package p\n")
+	if err := validateReplaceApplied(src, nil); err != nil {
+		t.Fatalf("nil checks must return nil: %v", err)
+	}
+}
+
+func TestValidateReplaceApplied_FailureMode_MissingReplacementErrors(t *testing.T) {
+	// The source intentionally lacks the replacement text. This simulates the
+	// silent-data-loss bug from issue #3 where the splice removed the match
+	// but the replacement was never inserted.
+	src := []byte(`package p
+
+func F() {
+}
+`)
+	checks := []replaceValidation{
+		{Index: 3, Replacement: "doImportantWork()"},
+	}
+	err := validateReplaceApplied(src, checks)
+	if err == nil {
+		t.Fatal("expected a PATCH_REPLACE_NOT_APPLIED error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "patch #3") {
+		t.Errorf("expected error to name patch index 3, got: %s", msg)
+	}
+	if !strings.Contains(msg, "doImportantWork()") {
+		t.Errorf("expected error preview to include the missing replacement text, got: %s", msg)
+	}
+	if !strings.Contains(msg, "rolled back") {
+		t.Errorf("expected error message to mention rollback semantics, got: %s", msg)
+	}
+}
+
+func TestValidateReplaceApplied_FailureMode_FirstMissingWins(t *testing.T) {
+	// When several replacements are checked and only the SECOND is missing,
+	// the error must point at index 2 — not 1.
+	src := []byte(`package p
+
+func F() {
+	doWork()
+}
+`)
+	checks := []replaceValidation{
+		{Index: 1, Replacement: "doWork()"},          // present
+		{Index: 2, Replacement: "missingFunction()"}, // missing
+	}
+	err := validateReplaceApplied(src, checks)
+	if err == nil {
+		t.Fatal("expected error for the missing second replacement")
+	}
+	if !strings.Contains(err.Error(), "patch #2") {
+		t.Errorf("expected error to name patch #2, got: %s", err.Error())
+	}
+}
+
+func TestValidateReplaceApplied_FailureMode_TruncatesLongReplacement(t *testing.T) {
+	// Long multi-line replacements should appear truncated in the message
+	// so the error stays compact.
+	long := strings.Repeat("a", 500)
+	checks := []replaceValidation{
+		{Index: 1, Replacement: long},
+	}
+	err := validateReplaceApplied([]byte("package p\n"), checks)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "...") {
+		t.Errorf("expected truncated preview to include ellipsis, got: %s", msg)
+	}
+	if strings.Count(msg, "a") > 200 {
+		t.Errorf("preview should be capped well under the input length, got %d a-chars", strings.Count(msg, "a"))
+	}
+}
+
+func TestTruncateReplacementPreview_FlattensNewlines(t *testing.T) {
+	got := truncateReplacementPreview("a\nb\nc", 100)
+	if got != `a\nb\nc` {
+		t.Errorf("expected newlines to be escaped, got: %q", got)
+	}
+}
+
+func TestTruncateReplacementPreview_TruncatesLong(t *testing.T) {
+	got := truncateReplacementPreview(strings.Repeat("x", 200), 50)
+	if !strings.HasSuffix(got, "...") {
+		t.Errorf("expected long input to be suffixed with ..., got: %q", got)
+	}
+	// The truncated body is exactly 50 runes, plus the trailing "..." marker.
+	if len(got) != 50+len("...") {
+		t.Errorf("expected 50 chars + ellipsis, got len=%d", len(got))
+	}
+}

--- a/internal/surgeon/inbound/mcp/schema_hint.go
+++ b/internal/surgeon/inbound/mcp/schema_hint.go
@@ -42,6 +42,13 @@ func schemaHintMiddleware() mcp.Middleware {
 				}
 				return res, nil
 			}
+			if msg := detectPatchOpFieldTypeMismatch(params.Arguments); msg != "" {
+				res := &mcp.CallToolResult{
+					Content: []mcp.Content{&mcp.TextContent{Text: msg}},
+					IsError: true,
+				}
+				return res, nil
+			}
 			return next(ctx, method, req)
 		}
 	}
@@ -98,4 +105,126 @@ func formatPatchesMismatchError(doubleSerialized bool) string {
 		"This is a client-side serialization issue: send 'patches' as a raw JSON array, not as a string containing JSON.\n" +
 		"Workaround: retry the same call (some clients are intermittent), or fall back to " +
 		"update_interface / update_struct / update with the full declaration."
+}
+
+// stringPatchFields lists the fields inside a single patch op that MUST
+// arrive as JSON strings. When a buggy client serializes a multi-line value
+// as a JSON array (e.g. one element per line) instead of a string with
+// embedded newlines, the SDK's default validator returns the same opaque
+// "type ... has type ... want string" message that triggered issue #3.
+var stringPatchFields = []string{
+	"replace",
+	"match",
+	"match_regex",
+	"code",
+	"wrap",
+	"signature",
+	"type",
+	"tag",
+	"doc",
+	"name",
+	"from",
+	"to",
+	"before",
+	"after",
+}
+
+// detectPatchOpFieldTypeMismatch inspects every entry in the 'patches'
+// array and reports the first patch op that has a non-string value in a
+// field that is documented as a string. Returns "" when patches is missing
+// or well-typed.
+//
+// The motivation is the silent-data-loss path described in issue #3:
+// agents occasionally send `replace: ["line1", "line2"]` instead of the
+// equivalent `replace: "line1\nline2"`, and the resulting validation error
+// is opaque enough that they don't act on it. This helper short-circuits
+// with an actionable message naming the offending patch index and field.
+func detectPatchOpFieldTypeMismatch(args json.RawMessage) string {
+	if len(args) == 0 {
+		return ""
+	}
+	var peek struct {
+		Patches json.RawMessage `json:"patches"`
+	}
+	if err := json.Unmarshal(args, &peek); err != nil {
+		return ""
+	}
+	if len(peek.Patches) == 0 {
+		return ""
+	}
+	trimmed := skipJSONWhitespace(peek.Patches)
+	if len(trimmed) == 0 || trimmed[0] != '[' {
+		// Not an array — the dedicated patches-string detector handles that
+		// case. Avoid double-reporting here.
+		return ""
+	}
+	var ops []map[string]json.RawMessage
+	if err := json.Unmarshal(peek.Patches, &ops); err != nil {
+		return ""
+	}
+	for i, op := range ops {
+		for _, field := range stringPatchFields {
+			raw, present := op[field]
+			if !present || len(raw) == 0 {
+				continue
+			}
+			head := skipJSONWhitespace(raw)
+			if len(head) == 0 {
+				continue
+			}
+			if head[0] == '"' || (head[0] == 'n' && string(head) == "null") {
+				continue
+			}
+			return formatPatchOpFieldTypeMismatchError(i+1, field, head[0])
+		}
+	}
+	return ""
+}
+
+// formatPatchOpFieldTypeMismatchError builds the agent-facing message when
+// a patch op field has the wrong JSON type. The first byte of the offending
+// value is included to disambiguate array vs object vs number.
+func formatPatchOpFieldTypeMismatchError(index int, field string, firstByte byte) string {
+	kind := "value"
+	switch firstByte {
+	case '[':
+		kind = "JSON array"
+	case '{':
+		kind = "JSON object"
+	case 't', 'f':
+		kind = "boolean"
+	default:
+		if firstByte >= '0' && firstByte <= '9' {
+			kind = "number"
+		} else if firstByte == '-' {
+			kind = "number"
+		}
+	}
+	return "ERROR: patch #" + itoa(index) + " field " + field + " arrived as a " + kind + ", but a string is required.\n" +
+		"Send '" + field + "' as a JSON string. Multi-line values use embedded \\n escapes: \"line1\\nline2\". " +
+		"Do NOT split lines into a JSON array."
+}
+
+// itoa is a tiny dependency-free integer formatter so this file stays
+// limited to encoding/json + the SDK package.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
 }

--- a/internal/surgeon/inbound/mcp/schema_hint_test.go
+++ b/internal/surgeon/inbound/mcp/schema_hint_test.go
@@ -174,3 +174,43 @@ func TestSchemaHint_PatchesIsUnrelatedString(t *testing.T) {
 	assert.Contains(t, text, "JSON-encoded string instead of an array")
 	assert.False(t, strings.Contains(text, "serialized twice"), "inner value is not a JSON array, should not claim double-serialization")
 }
+
+// TestSchemaHint_PatchOpReplaceAsArray verifies that a patch op whose
+// 'replace' field arrived as a JSON array (the silent-data-loss pattern
+// described in issue #3) is intercepted before the splice ever runs.
+// The middleware must return an actionable message naming the offending
+// patch index and field, and the business handler must not be invoked.
+func TestSchemaHint_PatchOpReplaceAsArray(t *testing.T) {
+	var called bool
+	commands := &mockCommands{
+		patchFunctionFn: func(_ context.Context, _ domain.PatchFunctionRequest) (domain.PatchFunctionResult, error) {
+			called = true
+			return domain.PatchFunctionResult{}, nil
+		},
+	}
+	cs := setupTest(t, commands, &mockQueries{})
+
+	result, err := cs.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: "patch",
+		Arguments: map[string]any{
+			"target":     "function",
+			"file":       "foo.go",
+			"identifier": "Foo",
+			"patches": []map[string]any{
+				{
+					"op":      "replace",
+					"match":   "x",
+					"replace": []string{"line1", "line2"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError, "expected the middleware to flag the bad type")
+	text := resultText(t, result)
+	assert.Contains(t, text, "patch #1")
+	assert.Contains(t, text, "replace")
+	assert.Contains(t, text, "JSON array")
+	assert.Contains(t, text, "string is required")
+	assert.False(t, called, "business handler must not run when the middleware rejects")
+}


### PR DESCRIPTION
## Summary

Closes #3 — silent data loss in `patch op=replace` when the replacement is mangled in transport.

- Adds a server-side `validateReplaceApplied` post-condition guard. After every `op=replace` patch in `patch_function`, `patch_decl`, and `patch_file`, the resulting source is checked to confirm the replacement text is actually present. On mismatch, the write is rolled back (the in-memory result is discarded before reaching `WriteFile`) and the call returns `PATCH_REPLACE_NOT_APPLIED` naming the offending patch index plus a truncated preview of the missing text.
- Validation runs against the in-memory assembled `newSrc` (or, in `patch_file`, the per-step `working` source) so the rollback is automatic — no on-disk re-read is needed and the existing happy-path tests continue to pass.
- Sequential `patch_file` patches are validated per-step rather than against the final source, so legitimate `"a"->"b"` then `"b"->"c"` chains keep working.
- Extends the existing `schemaHintMiddleware` with `detectPatchOpFieldTypeMismatch`: when an individual patch op's `replace`/`match`/`code`/etc. arrives as a JSON array, object, number, or boolean instead of a string (the multi-line-as-array client bug speculated in the issue), the request is rejected up-front with a message naming the offending patch index and field.
- `patch_struct` and `patch_interface` use AST-level operations (no text-splice `op=replace`), so they don't need the new guard.

## Test plan

- [x] `go test ./...` — 615 pass, 0 fail (was 602 — 13 new tests).
- [x] `golangci-lint run ./...` — 0 issues.
- [x] New unit tests for `validateReplaceApplied` cover present, absent, multi-line, whitespace-tolerant, empty-replacement, multiple-checks, and long-replacement-truncation cases.
- [x] New end-to-end `TestPatchFunction_Issue3_*` tests reproduce both cases from the issue (function body rewrite + struct-literal field insertion).
- [x] New `TestSchemaHint_PatchOpReplaceAsArray` test confirms the upfront type-mismatch rejection fires before the splice runs.
- [x] Existing `TestPatchFile_SequentialApplication` still passes — sequential patches that legitimately overwrite earlier replacements aren't blocked.
