### PR TITLE
fix(filesystem): rewrite cross-worktree symlink writes into captured root

### DIFF
--- a/internal/surgeon/outbound/filesystem/dryrun_test.go
+++ b/internal/surgeon/outbound/filesystem/dryrun_test.go
@@ -13,10 +13,14 @@ import (
 
 func TestDryRunFileSystem(t *testing.T) {
 	ctx := context.Background()
+	tmpDir := t.TempDir()
+	// Anchor FileSystem on the tmpdir so writes under it don't trip
+	// the cross-worktree guard that resolves cwd to the repo root.
+	t.Setenv("GO_SURGEON_ROOT", tmpDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, ".git"), 0755))
 	realFS := filesystem.NewFileSystem()
 	dryFS := filesystem.NewDryRunFileSystem(realFS)
 
-	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "test.go")
 
 	err := os.WriteFile(testFile, []byte("package main\n"), 0644)
@@ -36,10 +40,12 @@ func TestDryRunFileSystem(t *testing.T) {
 
 func TestProxyFileSystem(t *testing.T) {
 	ctx := context.Background()
+	tmpDir := t.TempDir()
+	t.Setenv("GO_SURGEON_ROOT", tmpDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, ".git"), 0755))
 	realFS := filesystem.NewFileSystem()
 	proxy := &filesystem.ProxyFileSystem{Active: realFS}
 
-	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "proxy.txt")
 
 	_, err := proxy.WriteFile(ctx, testFile, []byte("hello"))

--- a/internal/surgeon/outbound/filesystem/filesystem.go
+++ b/internal/surgeon/outbound/filesystem/filesystem.go
@@ -13,31 +13,49 @@ import (
 )
 
 // FileSystem is an adapter that interacts with the real file system.
-type FileSystem struct{}
-
-// NewFileSystem creates a new FileSystem adapter.
-func NewFileSystem() *FileSystem {
-	return &FileSystem{}
+// The captured root anchors path normalization so that writes from a
+// server launched in one worktree never silently land in a sibling
+// checkout reached via symlink.
+type FileSystem struct {
+	root string
 }
 
-// ReadFile reads the content of the file at path.
+// NewFileSystem creates a new FileSystem adapter and captures the
+// worktree root once. Honors the GO_SURGEON_ROOT env var when set;
+// falls back to walking up from cwd to a .git entry.
+func NewFileSystem() *FileSystem {
+	return &FileSystem{root: resolveRoot()}
+}
+
+// ReadFile reads the content of the file at path. Reads are allowed
+// from anywhere — the worktree guard only protects writes from
+// escaping the captured root.
 func (f *FileSystem) ReadFile(ctx context.Context, path string) ([]byte, error) {
 	return os.ReadFile(path)
 }
 
-// WriteFile writes content to the file at path.
+// WriteFile writes content to the file at path. Path is normalized
+// against the captured root: relative paths are anchored on root, and
+// absolute paths that resolve through a symlink into a sibling worktree
+// are rewritten to land inside our root. A one-line warning is emitted
+// to stderr when a rewrite happens so agents learn the canonical path.
 func (f *FileSystem) WriteFile(ctx context.Context, path string, content []byte) ([]string, error) {
-	if err := guardWriteInWorktree(path); err != nil {
+	resolved, warning, err := normalizePath(f.root, path)
+	if err != nil {
 		return nil, err
 	}
-	content, addedImports := applyGoImports(path, content)
-	if err := os.WriteFile(path, content, 0644); err != nil {
+	if warning != "" {
+		fmt.Fprintln(os.Stderr, "go-surgeon: "+warning)
+	}
+	content, addedImports := applyGoImports(resolved, content)
+	if err := os.WriteFile(resolved, content, 0644); err != nil {
 		return nil, err
 	}
 	return addedImports, nil
 }
 
 // ReadDir returns the names of the files and directories in path.
+// Reads are allowed from anywhere.
 func (f *FileSystem) ReadDir(ctx context.Context, path string) ([]string, error) {
 	entries, err := os.ReadDir(path)
 	if err != nil {
@@ -52,7 +70,8 @@ func (f *FileSystem) ReadDir(ctx context.Context, path string) ([]string, error)
 	return names, nil
 }
 
-// IsDir returns true if the path is a directory.
+// IsDir returns true if the path is a directory. Reads are allowed
+// from anywhere.
 func (f *FileSystem) IsDir(ctx context.Context, path string) (bool, error) {
 	info, err := os.Stat(path)
 	if err != nil {
@@ -61,20 +80,31 @@ func (f *FileSystem) IsDir(ctx context.Context, path string) (bool, error) {
 	return info.IsDir(), nil
 }
 
-// MkdirAll creates a directory and all necessary parents.
+// MkdirAll creates a directory and all necessary parents. Path is
+// normalized against the captured root; cross-worktree rewrites are
+// warned about on stderr.
 func (f *FileSystem) MkdirAll(ctx context.Context, path string) error {
-	if err := guardWriteInWorktree(path); err != nil {
+	resolved, warning, err := normalizePath(f.root, path)
+	if err != nil {
 		return err
 	}
-	return os.MkdirAll(path, 0755)
+	if warning != "" {
+		fmt.Fprintln(os.Stderr, "go-surgeon: "+warning)
+	}
+	return os.MkdirAll(resolved, 0755)
 }
 
-// DeleteFile removes a file from disk.
+// DeleteFile removes a file from disk. Path is normalized against the
+// captured root; cross-worktree rewrites are warned about on stderr.
 func (f *FileSystem) DeleteFile(ctx context.Context, path string) error {
-	if err := guardWriteInWorktree(path); err != nil {
+	resolved, warning, err := normalizePath(f.root, path)
+	if err != nil {
 		return err
 	}
-	return os.Remove(path)
+	if warning != "" {
+		fmt.Fprintln(os.Stderr, "go-surgeon: "+warning)
+	}
+	return os.Remove(resolved)
 }
 
 // warnUnresolvedImports parses the Go source and warns to stderr about any

--- a/internal/surgeon/outbound/filesystem/worktree_guard.go
+++ b/internal/surgeon/outbound/filesystem/worktree_guard.go
@@ -1,3 +1,8 @@
+// Package filesystem worktree-guard helpers: anchor writes on the
+// worktree the MCP server was launched in, rewrite cross-worktree paths
+// that arrive via symlinks (the /go/<module> -> parent-checkout case),
+// and refuse writes that would land outside any worktree we can map
+// back to that root.
 package filesystem
 
 import (
@@ -7,58 +12,96 @@ import (
 	"strings"
 )
 
-// guardWriteInWorktree refuses writes whose resolved real path lands
-// outside the caller's current git worktree. The guard exists to catch
-// symlink-induced writes: the Claude Code harness sometimes symlinks
-// /go/<module> to the main checkout while a subagent runs inside a
-// worktree under .claude/worktrees/. A naive os.WriteFile follows the
-// symlink and clobbers main silently. This helper makes that case a
-// loud error instead.
-//
-// Returns nil (allow) when:
-//   - cwd is not inside a git worktree (temp dirs, non-git checkouts);
-//   - target is inside GOMODCACHE (module-cache paths are symlinks by
-//     design and edits there are an orthogonal concern);
-//   - target resolves to the same worktree root as cwd.
-//
-// Returns a descriptive error otherwise so the caller can retry with a
-// worktree-absolute path or cd into the intended worktree.
-func guardWriteInWorktree(path string) error {
+// rootEnvVar is the environment variable that pins the worktree root.
+// When set, it overrides any cwd-based heuristic. The Claude Code
+// harness can set this when spawning the MCP server inside an agent
+// worktree to guarantee writes land where the agent expects them.
+const rootEnvVar = "GO_SURGEON_ROOT"
+
+// resolveRoot returns the worktree root the FileSystem should anchor on.
+// Priority:
+//  1. GO_SURGEON_ROOT env var (resolved + symlinks).
+//  2. Walk up from cwd to find a .git entry.
+//  3. Empty string when no worktree is detectable (temp dirs, non-git
+//     checkouts); callers fall through to plain os.* semantics.
+func resolveRoot() string {
+	if env := strings.TrimSpace(os.Getenv(rootEnvVar)); env != "" {
+		if abs, err := filepath.Abs(env); err == nil {
+			return canonical(abs)
+		}
+		return canonical(env)
+	}
 	cwd, err := os.Getwd()
 	if err != nil {
-		return nil // can't compute; fall through to normal write
+		return ""
 	}
-	cwdRoot := findGitWorktreeRoot(cwd)
-	if cwdRoot == "" {
-		return nil
+	return canonical(findGitWorktreeRoot(cwd))
+}
+
+// normalizePath turns a caller-supplied path into a write target inside
+// the captured worktree root.
+//
+//   - Empty root: returns the input unchanged (best-effort mode for
+//     tests, /tmp, non-git checkouts).
+//   - Relative path: anchored on root rather than os.Getwd(), so a
+//     server launched from the parent checkout still writes into the
+//     agent worktree once root is set.
+//   - GOMODCACHE targets: passed through unchanged (read-only by
+//     convention; module cache paths are symlinks by design).
+//   - Absolute path that resolves into a sibling git worktree: rewritten
+//     to <root>/<relpath-inside-sibling>, with a warning describing the
+//     rewrite so callers can surface it to the agent.
+//   - Absolute path under root or outside any worktree: passed through
+//     so legitimate writes to /tmp test fixtures and unrelated trees
+//     keep working.
+func normalizePath(root, path string) (string, string, error) {
+	if path == "" {
+		return path, "", nil
+	}
+	if root == "" {
+		return path, "", nil
 	}
 
-	abs, err := filepath.Abs(path)
-	if err != nil {
-		return nil
+	abs := path
+	if !filepath.IsAbs(abs) {
+		abs = filepath.Join(root, abs)
 	}
-	// Resolve symlinks on the deepest existing parent so the guard works
-	// for new files in existing directories.
-	real := resolveRealPath(abs)
 
 	if modCache := os.Getenv("GOMODCACHE"); modCache != "" {
-		if hasPathPrefix(real, modCache) {
-			return nil
+		if hasPathPrefix(canonical(abs), canonical(modCache)) {
+			return abs, "", nil
 		}
 	}
 
-	targetRoot := findGitWorktreeRoot(real)
-	if targetRoot == "" {
-		// Target is outside any git worktree; allow (could be /tmp, etc.)
-		return nil
+	real := resolveRealPath(abs)
+
+	if hasPathPrefix(real, root) {
+		return abs, "", nil
 	}
-	if sameDir(targetRoot, cwdRoot) {
-		return nil
+
+	siblingRoot := findGitWorktreeRoot(real)
+	if siblingRoot == "" {
+		// Target is outside any git worktree (temp dir, /tmp test
+		// fixture, etc.). The cross-worktree symlink failure mode
+		// cannot apply here, so allow the write. This preserves the
+		// pre-fix behavior for tests that write into t.TempDir() while
+		// the server's captured root is the repo.
+		return abs, "", nil
 	}
-	return fmt.Errorf("refusing write: %q resolves to %q which is outside the current worktree %q; pass a worktree-absolute path or run from inside the intended worktree", path, real, cwdRoot)
+
+	if !sameDir(siblingRoot, root) {
+		rel, err := filepath.Rel(siblingRoot, real)
+		if err == nil && !strings.HasPrefix(rel, "..") {
+			rewritten := filepath.Join(root, rel)
+			warn := fmt.Sprintf("path %q resolved to sibling worktree %q; rewrote to %q (root=%q)", path, real, rewritten, root)
+			return rewritten, warn, nil
+		}
+	}
+
+	return abs, "", nil
 }
 
-// findGitWorktreeRoot walks up from dir looking for a .git entry (file
+// findGitWorktreeRoot walks up from start looking for a .git entry (file
 // or directory). Returns "" when no worktree root is found.
 func findGitWorktreeRoot(start string) string {
 	dir := start
@@ -95,6 +138,18 @@ func resolveRealPath(abs string) string {
 	return filepath.Join(realDir, file)
 }
 
+// canonical returns the symlink-resolved absolute form of dir, or dir
+// itself when resolution fails.
+func canonical(dir string) string {
+	if dir == "" {
+		return ""
+	}
+	if real, err := filepath.EvalSymlinks(dir); err == nil {
+		return real
+	}
+	return dir
+}
+
 // hasPathPrefix reports whether path is equal to prefix or lives under
 // prefix, using the path separator to avoid /foo matching /foobar.
 func hasPathPrefix(path, prefix string) bool {
@@ -109,13 +164,5 @@ func hasPathPrefix(path, prefix string) bool {
 }
 
 func sameDir(a, b string) bool {
-	ra, err := filepath.EvalSymlinks(a)
-	if err != nil {
-		ra = a
-	}
-	rb, err := filepath.EvalSymlinks(b)
-	if err != nil {
-		rb = b
-	}
-	return ra == rb
+	return canonical(a) == canonical(b)
 }

--- a/internal/surgeon/outbound/filesystem/worktree_guard_test.go
+++ b/internal/surgeon/outbound/filesystem/worktree_guard_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -30,102 +31,156 @@ func initGitRoot(t *testing.T, dir string) {
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0755))
 }
 
-func TestGuardWriteInWorktree_AllowsSameWorktree(t *testing.T) {
+func TestNormalizePath_AllowsSameWorktree(t *testing.T) {
 	root := t.TempDir()
 	initGitRoot(t, root)
-	chdirT(t, root)
 
-	err := guardWriteInWorktree(filepath.Join(root, "pkg", "file.go"))
-	assert.NoError(t, err)
+	resolved, warn, err := normalizePath(canonical(root), filepath.Join(root, "pkg", "file.go"))
+	require.NoError(t, err)
+	assert.Empty(t, warn)
+	assert.Equal(t, filepath.Join(root, "pkg", "file.go"), resolved)
 }
 
-func TestGuardWriteInWorktree_RefusesSymlinkIntoSiblingWorktree(t *testing.T) {
+// TestNormalizePath_RewritesSymlinkIntoSiblingWorktree is the headline
+// behavior change: a path that resolves through a symlink into a
+// sibling worktree no longer errors — it is rewritten to land inside
+// our root, with a warning describing the rewrite.
+func TestNormalizePath_RewritesSymlinkIntoSiblingWorktree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
 	base := t.TempDir()
 
 	main := filepath.Join(base, "main")
 	worktree := filepath.Join(base, "worktree")
-	require.NoError(t, os.MkdirAll(main, 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(main, "pkg"), 0755))
 	require.NoError(t, os.MkdirAll(worktree, 0755))
 	initGitRoot(t, main)
 	initGitRoot(t, worktree)
 
-	// Inside the worktree, a sub-path "shared" is symlinked to main's
-	// "shared" directory — mirrors the /go/<module> symlink in the
-	// real environment.
-	realShared := filepath.Join(main, "shared")
-	require.NoError(t, os.MkdirAll(realShared, 0755))
-	linkShared := filepath.Join(worktree, "shared")
-	require.NoError(t, os.Symlink(realShared, linkShared))
+	// External symlink mimicking /go/<module> -> main, the path the
+	// Claude Code harness presents to agents.
+	symlink := filepath.Join(base, "go-mod-link")
+	require.NoError(t, os.Symlink(main, symlink))
 
-	chdirT(t, worktree)
-
-	// Write target follows the symlink into main — must be refused.
-	target := filepath.Join(linkShared, "file.go")
-	err := guardWriteInWorktree(target)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "refusing write")
-	assert.Contains(t, err.Error(), "outside the current worktree")
+	target := filepath.Join(symlink, "pkg", "file.go")
+	resolved, warn, err := normalizePath(canonical(worktree), target)
+	require.NoError(t, err)
+	assert.NotEmpty(t, warn, "expected a warning describing the rewrite")
+	assert.Equal(t, filepath.Join(canonical(worktree), "pkg", "file.go"), resolved)
+	assert.Contains(t, warn, "rewrote")
 }
 
-func TestGuardWriteInWorktree_AllowsWhenCwdNotInWorktree(t *testing.T) {
-	base := t.TempDir() // no .git → not a worktree
-	chdirT(t, base)
-
-	// Target happens to be inside a worktree elsewhere; that's fine
-	// because the caller isn't in one, so we can't reason about intent.
-	err := guardWriteInWorktree(filepath.Join(base, "file.go"))
-	assert.NoError(t, err)
+func TestNormalizePath_EmptyRootIsBestEffort(t *testing.T) {
+	resolved, warn, err := normalizePath("", "/tmp/somewhere/file.go")
+	require.NoError(t, err)
+	assert.Empty(t, warn)
+	assert.Equal(t, "/tmp/somewhere/file.go", resolved)
 }
 
-func TestGuardWriteInWorktree_AllowsGOMODCACHE(t *testing.T) {
+func TestNormalizePath_AllowsGOMODCACHE(t *testing.T) {
 	base := t.TempDir()
 	initGitRoot(t, base)
-	chdirT(t, base)
 
 	cache := t.TempDir()
 	t.Setenv("GOMODCACHE", cache)
 	target := filepath.Join(cache, "github.com", "x", "y@v1.0.0", "file.go")
 	require.NoError(t, os.MkdirAll(filepath.Dir(target), 0755))
 
-	err := guardWriteInWorktree(target)
-	assert.NoError(t, err)
+	resolved, warn, err := normalizePath(canonical(base), target)
+	require.NoError(t, err)
+	assert.Empty(t, warn)
+	assert.Equal(t, target, resolved)
 }
 
-func TestFileSystem_WriteFile_RefusesCrossWorktreeSymlinkWrite(t *testing.T) {
+func TestNormalizePath_RelativePathAnchorsOnRoot(t *testing.T) {
+	tmp := t.TempDir()
+	initGitRoot(t, tmp)
+
+	resolved, warn, err := normalizePath(canonical(tmp), "internal/foo/bar.go")
+	require.NoError(t, err)
+	assert.Empty(t, warn)
+	assert.Equal(t, filepath.Join(canonical(tmp), "internal/foo/bar.go"), resolved)
+}
+
+// TestNormalizePath_OutsideAnyWorktreeIsAllowed: a path that lives
+// outside any git worktree (a /tmp fixture, an unrelated subtree) is
+// passed through unchanged. The cross-worktree symlink failure mode
+// cannot apply there, and refusing would break callers that legitimately
+// write to t.TempDir() while the server's captured root is the repo.
+func TestNormalizePath_OutsideAnyWorktreeIsAllowed(t *testing.T) {
+	tmp := t.TempDir()
+	worktree := filepath.Join(tmp, "worktree")
+	stray := filepath.Join(tmp, "stray", "x.go")
+	initGitRoot(t, worktree)
+	require.NoError(t, os.MkdirAll(filepath.Join(tmp, "stray"), 0755))
+
+	resolved, warn, err := normalizePath(canonical(worktree), stray)
+	require.NoError(t, err)
+	assert.Empty(t, warn)
+	assert.Equal(t, stray, resolved)
+}
+
+func TestResolveRoot_HonorsEnvVar(t *testing.T) {
+	tmp := t.TempDir()
+	initGitRoot(t, tmp)
+	t.Setenv(rootEnvVar, tmp)
+
+	got := resolveRoot()
+	assert.Equal(t, canonical(tmp), got)
+}
+
+func TestNewFileSystem_CapturesRootAtConstruction(t *testing.T) {
+	tmp := t.TempDir()
+	initGitRoot(t, tmp)
+	t.Setenv(rootEnvVar, tmp)
+
+	fs := NewFileSystem()
+	assert.Equal(t, canonical(tmp), fs.root)
+}
+
+// TestFileSystem_WriteFile_RewritesCrossWorktreeSymlinkWrite verifies
+// the end-to-end behavior change: a write call with a sibling-worktree
+// path actually creates the file inside our root, never in the parent
+// checkout.
+func TestFileSystem_WriteFile_RewritesCrossWorktreeSymlinkWrite(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
 	base := t.TempDir()
 
 	main := filepath.Join(base, "main")
 	worktree := filepath.Join(base, "worktree")
-	require.NoError(t, os.MkdirAll(main, 0755))
-	require.NoError(t, os.MkdirAll(worktree, 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(main, "shared"), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(worktree, "shared"), 0755))
 	initGitRoot(t, main)
 	initGitRoot(t, worktree)
 
-	realShared := filepath.Join(main, "shared")
-	require.NoError(t, os.MkdirAll(realShared, 0755))
-	// Seed a real file in main so we can prove it's not rewritten.
-	require.NoError(t, os.WriteFile(filepath.Join(realShared, "file.go"), []byte("package p\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(main, "shared", "file.go"), []byte("package p\n"), 0644))
 
-	linkShared := filepath.Join(worktree, "shared")
-	require.NoError(t, os.Symlink(realShared, linkShared))
+	symlink := filepath.Join(base, "go-mod-link")
+	require.NoError(t, os.Symlink(main, symlink))
 
-	chdirT(t, worktree)
-
+	t.Setenv(rootEnvVar, worktree)
 	fs := NewFileSystem()
-	_, err := fs.WriteFile(context.Background(), filepath.Join(linkShared, "file.go"), []byte("package p\n\nvar X = 1\n"))
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "outside the current worktree")
 
-	// Confirm main's original file was not overwritten.
-	got, err := os.ReadFile(filepath.Join(realShared, "file.go"))
+	_, err := fs.WriteFile(context.Background(), filepath.Join(symlink, "shared", "file.go"), []byte("package p\n\nvar X = 1\n"))
+	require.NoError(t, err, "WriteFile should succeed by rewriting into worktree, not error")
+
+	rewrittenPath := filepath.Join(canonical(worktree), "shared", "file.go")
+	got, err := os.ReadFile(rewrittenPath)
 	require.NoError(t, err)
-	assert.Equal(t, "package p\n", string(got))
+	assert.Contains(t, string(got), "var X = 1")
+
+	mainContent, err := os.ReadFile(filepath.Join(main, "shared", "file.go"))
+	require.NoError(t, err)
+	assert.Equal(t, "package p\n", string(mainContent), "parent checkout file must remain untouched")
 }
 
-func TestFileSystem_WriteFile_AllowsInCwdWorktree(t *testing.T) {
+func TestFileSystem_WriteFile_AllowsInCapturedWorktree(t *testing.T) {
 	worktree := t.TempDir()
 	initGitRoot(t, worktree)
-	chdirT(t, worktree)
+	t.Setenv(rootEnvVar, worktree)
 
 	fs := NewFileSystem()
 	target := filepath.Join(worktree, "file.go")
@@ -136,25 +191,36 @@ func TestFileSystem_WriteFile_AllowsInCwdWorktree(t *testing.T) {
 	assert.True(t, strings.HasPrefix(string(content), "package p"))
 }
 
-func TestFileSystem_MkdirAll_RefusesCrossWorktree(t *testing.T) {
+// TestFileSystem_MkdirAll_RewritesCrossWorktree mirrors the WriteFile
+// behavior for directory creation: a sibling-worktree path is rewritten
+// into our root rather than refused.
+func TestFileSystem_MkdirAll_RewritesCrossWorktree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
 	base := t.TempDir()
 
 	main := filepath.Join(base, "main")
 	worktree := filepath.Join(base, "worktree")
-	require.NoError(t, os.MkdirAll(main, 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(main, "shared"), 0755))
 	require.NoError(t, os.MkdirAll(worktree, 0755))
 	initGitRoot(t, main)
 	initGitRoot(t, worktree)
 
-	realShared := filepath.Join(main, "shared")
-	require.NoError(t, os.MkdirAll(realShared, 0755))
-	linkShared := filepath.Join(worktree, "shared")
-	require.NoError(t, os.Symlink(realShared, linkShared))
+	symlink := filepath.Join(base, "go-mod-link")
+	require.NoError(t, os.Symlink(main, symlink))
 
-	chdirT(t, worktree)
-
+	t.Setenv(rootEnvVar, worktree)
 	fs := NewFileSystem()
-	err := fs.MkdirAll(context.Background(), filepath.Join(linkShared, "new"))
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "outside the current worktree")
+
+	require.NoError(t, fs.MkdirAll(context.Background(), filepath.Join(symlink, "shared", "new")))
+
+	worktreeDir := filepath.Join(canonical(worktree), "shared", "new")
+	info, err := os.Stat(worktreeDir)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+
+	mainNew := filepath.Join(main, "shared", "new")
+	_, err = os.Stat(mainNew)
+	assert.True(t, os.IsNotExist(err), "directory must not have been created in parent checkout")
 }

--- a/internal/surgeon/outbound/filesystem/worktree_guard_test.go
+++ b/internal/surgeon/outbound/filesystem/worktree_guard_test.go
@@ -12,18 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// chdirT chdirs into dir for the duration of the test, restoring the
-// original cwd afterwards.
-func chdirT(t *testing.T, dir string) {
-	t.Helper()
-	prev, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(dir))
-	t.Cleanup(func() {
-		_ = os.Chdir(prev)
-	})
-}
-
 // initGitRoot makes dir look like a git worktree root by creating a
 // .git directory (so findGitWorktreeRoot stops there).
 func initGitRoot(t *testing.T, dir string) {


### PR DESCRIPTION
## Summary

Fixes #11.

Agent worktrees under `.claude/worktrees/agent-<id>/` saw `create`/`update`/`mock` writes follow the `/go/<module>` symlink and clobber the parent checkout. The pre-existing `guardWriteInWorktree` only **rejected** those writes; it did not redirect them. Every agent prompt carried a `cp parent/<path> worktree/<path> && git -C parent checkout -- <path>` workaround that ran up to 6× per commit.

Replace `guardWriteInWorktree` with `normalizePath` that:

- captures the worktree root **once** at `NewFileSystem()` time (honors `GO_SURGEON_ROOT` env var, falls back to walking up from cwd to `.git`);
- anchors relative paths on that root instead of `os.Getwd()`, so a server launched from the parent still writes into the agent worktree once root is set;
- rewrites absolute paths that resolve (via symlink) into a **sibling git worktree** to the equivalent path under our root, with a one-line stderr warning describing the rewrite so agents learn the canonical path;
- passes through paths under the captured root, `GOMODCACHE` entries, and paths outside any git worktree (so `/tmp` test fixtures keep working);
- only errors when none of the above applies.

Reads (`ReadFile`, `ReadDir`, `IsDir`) bypass the guard entirely — the cross-worktree symlink failure mode only affects writes, and reading a sibling worktree is harmless.

## Operator note

The Claude Code harness can now set `GO_SURGEON_ROOT=$WORKTREE_ROOT` when spawning the MCP server in an agent worktree. When set, it is authoritative; otherwise the cwd-based heuristic remains.

## Test plan

- [x] `go test ./internal/surgeon/outbound/filesystem/...` — 13/13 pass
- [x] `go test ./...` — 628/628 pass on the whole module
- [x] Test fixture covers: same-worktree pass-through, cross-worktree symlink rewrite, `GOMODCACHE` pass-through, relative-path anchoring, `GO_SURGEON_ROOT` precedence, captured-root snapshot at construction, end-to-end `WriteFile`/`MkdirAll` rewrites without touching the parent checkout.