### PR TITLE
fix(patch): clearer set_doc error message (refs #15)

### DIFF
--- a/internal/surgeon/app/commands/patch_struct.go
+++ b/internal/surgeon/app/commands/patch_struct.go
@@ -315,7 +315,7 @@ func applyStructPatch(working *[]*element, original []*element, p domain.StructP
 
 	case domain.StructPatchOpSetDoc:
 		if p.Name == "" {
-			return "name is required"
+			return "set_doc on a struct field requires name (the field whose doc you want to set); to set the struct's own doc comment, use 'update object=struct' with a doc field — see issue #15"
 		}
 		idx := findElement(*working, p.Name)
 		if idx == -1 {


### PR DESCRIPTION
## Summary

Partial fix for #15. Improve the `name is required` error on `patch target=struct op=set_doc` so agents understand the op only handles **field-level** docs and that the struct-level case is not yet implemented. The new message redirects to `update object=struct` as the working alternative.

This stops the guess-and-retry cycle when an agent reasonably tries to set a struct's own doc via `set_doc`. The full fix — supporting `set_doc` on the struct itself when `name` is empty — is left for a follow-up since it needs to touch `GenDecl.Doc` rendering, not just the field-list path.

## Test plan

- [x] `go test ./internal/surgeon/app/commands/...` — 45 PatchStruct tests pass
- [x] `go build ./...` clean

Issue #15 stays open until the struct-level form is implemented.